### PR TITLE
Fetch pricing tiers + display in week table

### DIFF
--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -4,7 +4,7 @@
   <app-auth/>
   @if (user$ | async) {
     Year: {{ configYear }}
-    <week-table [weeks]="(weeks$ | async) || []" [units]="(units$ | async) || []"/>
+    <week-table [weeks]="(weeks$ | async) || []" [units]="(units$ | async) || []" [pricingTiers]="(pricingTiers$ | async) || {}"/>
   } @else {
     <p>
       Please log in

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -1,5 +1,6 @@
 export interface WeekConfig {
   startDate: string;
+  pricingTierId: string;
 }
 
 export interface ConfigData {
@@ -8,5 +9,14 @@ export interface ConfigData {
 }
 
 export interface BookableUnit {
+  id: string;
   name: string;
 }
+
+export interface PricingTier {
+  id: string;
+  name: string;
+  color: number[];
+}
+
+export type PricingTierMap = {[key: string]: PricingTier};

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -1,19 +1,20 @@
-<table mat-table [dataSource]="weeks">
+<table mat-table [dataSource]="tableRows$">
   <!-- Week Start Column -->
   <ng-container matColumnDef="week">
     <th mat-header-cell *matHeaderCellDef> Week </th>
     <td mat-cell *matCellDef="let element">
       {{element.startDate | shortDate }} –
-      {{element.endDate | shortDate}}
+      {{element.endDate | shortDate}}<br>
+      {{element.pricingTier?.name || ''}}
     </td>
   </ng-container>
 
   <!-- Unit Columns -->
   <ng-container *ngFor="let unit of units" [matColumnDef]="unit.name">
-    <th mat-header-cell *matHeaderCellDef> {{unit.name}} </th>
+    <th mat-header-cell *matHeaderCellDef> {{unit.name}}</th>
     <td mat-cell *matCellDef="let element"> – </td>
   </ng-container>
 
   <tr mat-header-row *matHeaderRowDef="displayedColumns"></tr>
-  <tr mat-row *matRowDef="let row; columns: displayedColumns"></tr>
+  <tr mat-row *matRowDef="let row; columns: displayedColumns" [style]="rowStyle(row)"></tr>
 </table>

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -1,4 +1,4 @@
-import {Component, Input, OnDestroy} from '@angular/core';
+import {Component, Input} from '@angular/core';
 import {AsyncPipe, NgForOf} from '@angular/common';
 import {
   MatCell,
@@ -13,21 +13,13 @@ import {
   MatTable
 } from '@angular/material/table';
 import {ShortDate} from './utility/short-date.pipe';
-import {BehaviorSubject} from 'rxjs';
-import {BookableUnit, WeekConfig} from './types';
+import {Observable, of} from 'rxjs';
+import {BookableUnit, PricingTier, PricingTierMap, WeekConfig} from './types';
 
 interface WeekRow {
   startDate: Date;
   endDate: Date;
-}
-
-function weeksTransformer(weeks: WeekConfig[]): WeekRow[] {
-  return weeks.map(week => {
-    const startDate = new Date(Date.parse(week.startDate));
-    const endDate = new Date(startDate);
-    endDate.setDate(endDate.getDate() + 6);
-    return {startDate, endDate};
-  });
+  pricingTier: PricingTier;
 }
 
 @Component({
@@ -51,34 +43,59 @@ function weeksTransformer(weeks: WeekConfig[]): WeekRow[] {
   templateUrl: './week-table.component.html',
   styleUrl: './week-table.component.css'
 })
-export class WeekTableComponent implements OnDestroy {
+export class WeekTableComponent {
   // Input fields
-  @Input({transform: weeksTransformer})
-  weeks: WeekConfig[] = [];
+  private _weeks: WeekConfig[] = [];
+  private _pricingTiers: PricingTierMap = {};
   private _units: BookableUnit[] = [];
 
+  // Main table fields
+  tableRows$: Observable<WeekRow[]> = of([])
   displayedColumns: string[] = [];
 
-  // Computed fields
-  unitNames$ = new BehaviorSubject<string[]>([]);
-  unitNamesSubscription = this.unitNames$.subscribe(
-    names => {
-      this.displayedColumns = ['week', ...names];
-    }
-  );
+  buildTableRows(weeks: WeekConfig[], units: BookableUnit[], pricingTiers: PricingTierMap): Observable<WeekRow[]> {
+    this.displayedColumns = ['week', ...units.map(unit => unit.name)];
+    return of(
+      weeks.map(week => {
+        const startDate = new Date(Date.parse(week.startDate));
+        const endDate = new Date(startDate);
+        endDate.setDate(endDate.getDate() + 6);
+        const pricingTier = pricingTiers[week.pricingTierId];
 
-  ngOnDestroy(): void {
-    this.unitNamesSubscription?.unsubscribe();
+        return {startDate, endDate, pricingTier};
+      })
+    );
   }
-
 
   @Input()
   set units(value: BookableUnit[]) {
     this._units = value;
-    this.unitNames$.next(value.map(unit => unit.name));
+    this.tableRows$ = this.buildTableRows(this._weeks, this._units, this._pricingTiers);
+  }
+  get units() {
+    return this._units;
   }
 
-  get units(): BookableUnit[] {
-    return this._units;
+  @Input()
+  set weeks(value: WeekConfig[]) {
+    this._weeks = value;
+    this.tableRows$ = this.buildTableRows(this._weeks, this._units, this._pricingTiers);
+  }
+
+  @Input()
+  set pricingTiers(value: PricingTierMap) {
+    this._pricingTiers = value;
+    this.tableRows$ = this.buildTableRows(this._weeks, this._units, this._pricingTiers);
+  }
+
+  // Helper functions
+
+  rowStyle(row: WeekRow) {
+    if (row.pricingTier) {
+      const colorRgb = row.pricingTier.color.join(' ');
+      return `background-color: rgb(${colorRgb} / 0.05)`;
+    } else {
+      return '';
+    }
   }
 }


### PR DESCRIPTION
Read the pricing tiers into a map from id to tier. Then, send this into the week table, which looks up a week's assigned tier to display tier name and row color.

Simplify the week table's data management to rebuild the rows on each input change. Could this become a performance problem if, one day, we render >15 rows? 🔮

Fixes #15 