### PR TITLE
Restrict reservation edits

### DIFF
--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -5,8 +5,10 @@
     Year: {{ dataService.configYear }}
     <week-table
       [bookers]="(bookers$ | async) || []"
+      [currentBooker]="(currentBooker$ | async) || undefined"
       [weeks]="(weeks$ | async) || []"
       [units]="(units$ | async) || []"
+      [permissions]="(permissions$ | async) || {adminUserIds: []}"
       [pricingTiers]="(pricingTiers$ | async) || {}"
       [reservations]="(reservations$ | async) || []"
       [unitPricing]="(unitPricing$ | async) || {}"

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -1,12 +1,12 @@
 import {Component, inject} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
 import {Firestore} from '@angular/fire/firestore';
-import {AsyncPipe, NgForOf} from '@angular/common';
+import {AsyncPipe} from '@angular/common';
 import {AuthComponent} from './auth/auth.component';
 import {Auth, user} from '@angular/fire/auth';
-import {Observable} from 'rxjs';
+import {combineLatest, map, Observable} from 'rxjs';
 import {WeekTableComponent} from './week-table.component';
-import {BookableUnit, Booker, PricingTier, ReservableWeek, Reservation, UnitPricingMap} from './types';
+import {BookableUnit, Booker, Permissions, PricingTier, ReservableWeek, Reservation, UnitPricingMap} from './types';
 import {DataService} from './data-service';
 
 
@@ -18,7 +18,6 @@ import {DataService} from './data-service';
     AsyncPipe,
     AuthComponent,
     WeekTableComponent,
-    NgForOf,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
@@ -32,19 +31,26 @@ export class AppComponent {
   title = 'Reservations-App';
 
   bookers$: Observable<Booker[]>;
+  currentBooker$: Observable<Booker | undefined>;
   weeks$: Observable<ReservableWeek[]>;
   reservations$: Observable<Reservation[]>;
   units$: Observable<BookableUnit[]>;
+  permissions$: Observable<Permissions>;
   pricingTiers$: Observable<{ [key: string]: PricingTier }>;
   unitPricing$: Observable<UnitPricingMap>;
 
   constructor(dataService: DataService) {
     this.dataService = dataService;
     this.bookers$ = dataService.bookers$;
+    this.permissions$ = dataService.permissions$;
     this.pricingTiers$ = dataService.pricingTiers$;
     this.reservations$ = dataService.reservations$;
     this.unitPricing$ = dataService.unitPricing$;
     this.units$ = dataService.units$;
     this.weeks$ = dataService.weeks$;
+
+    this.currentBooker$ = combineLatest([dataService.bookers$, this.user$]).pipe(
+      map(([bookers, user]) => bookers.find(booker => booker.userId === user?.uid))
+    )
   }
 }

--- a/hosting/src/app/reservations/reserve-dialog.component.ts
+++ b/hosting/src/app/reservations/reserve-dialog.component.ts
@@ -95,7 +95,7 @@ export class ReserveDialog {
     this.reservationStartDate.set(data.startDate || data.weekStartDate);
     this.reservationEndDate.set(data.endDate || data.weekEndDate);
     this.guestName.set(data.initialGuestName || '');
-    this.bookerId.set(data.initialBookerId || '');
+    this.bookerId.set(data.initialBookerId || (this.bookers.length == 1 ? this.bookers[0].id : ''));
     this.existingReservationId = data.existingReservationId;
   }
 

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -6,11 +6,16 @@ export interface BookableUnit {
 export interface Booker {
   id: string;
   name: string;
+  userId: string;
 }
 
 export interface ConfigData {
   year: number;
   weeks: ReservableWeek[];
+}
+
+export interface Permissions {
+  adminUserIds: string[];
 }
 
 export interface PricingTier {

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -24,11 +24,13 @@
           <span>
             {{ reservation.guestName }} ({{ bookerName(reservation.bookerId) || 'unknown' }})
           </span>
-          <span class="mat-button-small" style="float: right">
-            <button mat-icon-button aria-label="Edit reservation" (click)="editReservation(reservation, weekRow)">
-              <mat-icon>edit</mat-icon>
-            </button>
-          </span>
+          @if (canEditReservation(reservation)) {
+            <span class="mat-button-small" style="float: right">
+              <button mat-icon-button aria-label="Edit reservation" (click)="editReservation(reservation, weekRow)">
+                <mat-icon>edit</mat-icon>
+              </button>
+            </span>
+          }
         </div>
       } @else {
         <div class="add-button">

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -138,7 +138,7 @@ export class WeekTableComponent {
             endDate: new Date(Date.parse(reservation.endDate)),
             unit,
             guestName: reservation.guestName,
-            bookerId: (reservation as any).bookerId,
+            bookerId: reservation.bookerId,
           } as WeekReservation;
         });
 

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -211,6 +211,10 @@ export class WeekTableComponent {
     });
   }
 
+  canEditReservation(reservation: WeekReservation): boolean {
+    return true;
+  }
+
   editReservation(reservation: WeekReservation, week: WeekRow) {
     const unit = reservation.unit;
     const tier = week.pricingTier;


### PR DESCRIPTION
Fixes #32 

A booker can only edit their own reservations.

<img width="1221" alt="Screenshot 2024-12-29 at 11 45 53 PM" src="https://github.com/user-attachments/assets/45fcc6b6-25cc-418b-a4ed-57db9bdbecb0" />

bookers can only reserve for themselves:

<img width="806" alt="Screenshot 2024-12-29 at 11 46 06 PM" src="https://github.com/user-attachments/assets/cd6e043b-4a0a-47d5-b23c-a74b78d7db9a" />


An admin can edit all reservations.

<img width="1231" alt="Screenshot 2024-12-29 at 11 45 28 PM" src="https://github.com/user-attachments/assets/aca8c19f-4d33-4b5a-b85b-3e9aa4e985f7" />

And reserve for everybody:

<img width="828" alt="Screenshot 2024-12-29 at 11 45 39 PM" src="https://github.com/user-attachments/assets/a1795490-e5df-490f-aa68-205b6e0593b6" />

