### PR TITLE
Restrict reservations to rounds

### DIFF
--- a/hosting/src/app/app.component.css
+++ b/hosting/src/app/app.component.css
@@ -3,4 +3,6 @@ main {
   align-items: center;
   margin-left: 10%;
   margin-right: 10%;
+
+  padding-bottom: 48px;
 }

--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -3,6 +3,7 @@
   <p>Today is: {{ today().toISODate() }}</p>
   @if (isAdmin()) {
     <today-picker [today]="today()"></today-picker>
+    <booker-picker (bookerId)="bookerIdOverride.set($event)" [bookers$]="bookers$"></booker-picker>
   }
   <app-auth/>
   @if (user$ | async) {

--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -1,6 +1,6 @@
 <main class="main">
   <h1>{{ title }}</h1>
-  <p>Today is: {{today().toISODate()}}</p>
+  <p>Today is: {{ today().toISODate() }}</p>
   @if (isAdmin()) {
     <today-picker [today]="today()"></today-picker>
   }
@@ -17,6 +17,7 @@
       [reservations]="(reservations$ | async) || []"
       [unitPricing]="(unitPricing$ | async) || {}"
     />
+    <round-config [rounds$]="reservationRounds$" [bookers$]="bookers$"/>
   } @else {
     <p>
       Please log in

--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -12,6 +12,9 @@
     </mat-chip>
     <mat-chip>
       Current round: {{ reservationRoundsService.currentRound()?.name || 'none' }}
+      @if (reservationRoundsService.currentSubRoundBooker()) {
+        ({{ reservationRoundsService.currentSubRoundBooker()?.name }})
+      }
     </mat-chip>
     <week-table
       [bookers]="(bookers$ | async) || []"

--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -7,7 +7,12 @@
   }
   <app-auth/>
   @if (user$ | async) {
-    Year: {{ dataService.configYear }}
+    <mat-chip>
+      Year: {{ dataService.configYear }}
+    </mat-chip>
+    <mat-chip>
+      Current round: {{ reservationRoundsService.currentRound()?.name || 'none' }}
+    </mat-chip>
     <week-table
       [bookers]="(bookers$ | async) || []"
       [currentBooker]="(currentBooker$ | async) || undefined"

--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -1,5 +1,9 @@
 <main class="main">
   <h1>{{ title }}</h1>
+  <p>Today is: {{today().toISODate()}}</p>
+  @if (isAdmin()) {
+    <today-picker [today]="today()"></today-picker>
+  }
   <app-auth/>
   @if (user$ | async) {
     Year: {{ dataService.configYear }}

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -1,13 +1,16 @@
-import {Component, inject} from '@angular/core';
+import {Component, inject, OnDestroy, signal, Signal} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
 import {Firestore} from '@angular/fire/firestore';
 import {AsyncPipe} from '@angular/common';
 import {AuthComponent} from './auth/auth.component';
-import {Auth, user} from '@angular/fire/auth';
+import {Auth, User, user} from '@angular/fire/auth';
 import {combineLatest, map, Observable} from 'rxjs';
 import {WeekTableComponent} from './week-table.component';
 import {BookableUnit, Booker, Permissions, PricingTier, ReservableWeek, Reservation, UnitPricingMap} from './types';
 import {DataService} from './data-service';
+import {DateTime} from 'luxon';
+import {TodayService} from './utility/today-service';
+import {TodayPicker} from './utility/today-picker.component';
 
 
 @Component({
@@ -18,15 +21,21 @@ import {DataService} from './data-service';
     AsyncPipe,
     AuthComponent,
     WeekTableComponent,
+    TodayPicker,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
 })
-export class AppComponent {
+export class AppComponent implements OnDestroy {
   private readonly auth = inject(Auth);
   protected readonly dataService;
+  private readonly todayService = inject(TodayService);
   user$ = user(this.auth);
+  private currentUser?: User;
+  private currentPermissions?: Permissions;
   private readonly firestore = inject(Firestore);
+
+  today: Signal<DateTime>;
 
   title = 'Reservations-App';
 
@@ -38,6 +47,10 @@ export class AppComponent {
   permissions$: Observable<Permissions>;
   pricingTiers$: Observable<{ [key: string]: PricingTier }>;
   unitPricing$: Observable<UnitPricingMap>;
+
+  isAdmin = signal(false);
+  currentUserSubscription;
+  permissionsSubscription;
 
   constructor(dataService: DataService) {
     this.dataService = dataService;
@@ -52,5 +65,22 @@ export class AppComponent {
     this.currentBooker$ = combineLatest([dataService.bookers$, this.user$]).pipe(
       map(([bookers, user]) => bookers.find(booker => booker.userId === user?.uid))
     )
+
+    this.today = this.todayService.today;
+
+    this.currentUserSubscription = this.user$.subscribe(user => {
+      this.currentUser = user || undefined
+      this.isAdmin.set(!!this.currentUser && !!this.currentPermissions && this.currentPermissions?.adminUserIds.includes(this.currentUser.uid));
+    });
+
+    this.permissionsSubscription = this.permissions$.subscribe(permissions => {
+      this.currentPermissions = permissions || undefined;
+      this.isAdmin.set(!!this.currentUser && this.currentPermissions?.adminUserIds.includes(this.currentUser.uid));
+    })
+  }
+
+  ngOnDestroy() {
+    this.permissionsSubscription.unsubscribe();
+    this.currentUserSubscription.unsubscribe();
   }
 }

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -6,11 +6,22 @@ import {AuthComponent} from './auth/auth.component';
 import {Auth, User, user} from '@angular/fire/auth';
 import {combineLatest, map, Observable} from 'rxjs';
 import {WeekTableComponent} from './week-table.component';
-import {BookableUnit, Booker, Permissions, PricingTier, ReservableWeek, Reservation, UnitPricingMap} from './types';
+import {
+  BookableUnit,
+  Booker,
+  Permissions,
+  PricingTier,
+  ReservableWeek,
+  Reservation,
+  ReservationRound,
+  UnitPricingMap
+} from './types';
 import {DataService} from './data-service';
 import {DateTime} from 'luxon';
 import {TodayService} from './utility/today-service';
 import {TodayPicker} from './utility/today-picker.component';
+import {ReservationRoundsService} from './reservations/reservation-rounds-service';
+import {RoundConfigComponent} from './reservations/round-config.component';
 
 
 @Component({
@@ -22,6 +33,7 @@ import {TodayPicker} from './utility/today-picker.component';
     AuthComponent,
     WeekTableComponent,
     TodayPicker,
+    RoundConfigComponent,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
@@ -42,6 +54,7 @@ export class AppComponent implements OnDestroy {
   bookers$: Observable<Booker[]>;
   currentBooker$: Observable<Booker | undefined>;
   weeks$: Observable<ReservableWeek[]>;
+  reservationRounds$: Observable<ReservationRound[]>;
   reservations$: Observable<Reservation[]>;
   units$: Observable<BookableUnit[]>;
   permissions$: Observable<Permissions>;
@@ -52,11 +65,12 @@ export class AppComponent implements OnDestroy {
   currentUserSubscription;
   permissionsSubscription;
 
-  constructor(dataService: DataService) {
+  constructor(dataService: DataService, reservationRoundsService: ReservationRoundsService) {
     this.dataService = dataService;
     this.bookers$ = dataService.bookers$;
     this.permissions$ = dataService.permissions$;
     this.pricingTiers$ = dataService.pricingTiers$;
+    this.reservationRounds$ = reservationRoundsService.reservationRounds$;
     this.reservations$ = dataService.reservations$;
     this.unitPricing$ = dataService.unitPricing$;
     this.units$ = dataService.units$;

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -24,6 +24,7 @@ import {ReservationRoundsService} from './reservations/reservation-rounds-servic
 import {RoundConfigComponent} from './reservations/round-config.component';
 import {BookerPickerComponent} from './utility/booker-picker.component';
 import {toObservable} from '@angular/core/rxjs-interop';
+import {MatChip} from '@angular/material/chips';
 
 
 @Component({
@@ -37,6 +38,7 @@ import {toObservable} from '@angular/core/rxjs-interop';
     TodayPicker,
     RoundConfigComponent,
     BookerPickerComponent,
+    MatChip,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
@@ -44,6 +46,7 @@ import {toObservable} from '@angular/core/rxjs-interop';
 export class AppComponent implements OnDestroy {
   private readonly auth = inject(Auth);
   protected readonly dataService;
+  protected readonly reservationRoundsService = inject(ReservationRoundsService);
   private readonly todayService = inject(TodayService);
   user$ = user(this.auth);
   private currentUser?: User;

--- a/hosting/src/app/app.config.ts
+++ b/hosting/src/app/app.config.ts
@@ -13,6 +13,7 @@ import {DialogService} from './utility/dialog-service';
 import {MatDialog} from '@angular/material/dialog';
 import {provideLuxonDateAdapter} from '@angular/material-luxon-adapter';
 import {TodayService} from './utility/today-service';
+import {ReservationRoundsService} from './reservations/reservation-rounds-service';
 
 export const ANIMATION_SETTINGS = {
   enterAnimationDuration: "250ms",
@@ -48,6 +49,7 @@ export const appConfig: ApplicationConfig = {
     provideAnimationsAsync(),
     {provide: MatDialog, useClass: DialogService},
     provideLuxonDateAdapter(),
+    {provide: ReservationRoundsService},
     {provide: TodayService},
   ],
 };

--- a/hosting/src/app/app.config.ts
+++ b/hosting/src/app/app.config.ts
@@ -12,6 +12,7 @@ import {provideAnimationsAsync} from '@angular/platform-browser/animations/async
 import {DialogService} from './utility/dialog-service';
 import {MatDialog} from '@angular/material/dialog';
 import {provideLuxonDateAdapter} from '@angular/material-luxon-adapter';
+import {TodayService} from './utility/today-service';
 
 export const ANIMATION_SETTINGS = {
   enterAnimationDuration: "250ms",
@@ -47,5 +48,6 @@ export const appConfig: ApplicationConfig = {
     provideAnimationsAsync(),
     {provide: MatDialog, useClass: DialogService},
     provideLuxonDateAdapter(),
+    {provide: TodayService},
   ],
 };

--- a/hosting/src/app/data-service.ts
+++ b/hosting/src/app/data-service.ts
@@ -9,6 +9,7 @@ import {
   PricingTierMap,
   ReservableWeek,
   Reservation,
+  ReservationRoundsConfig,
   UnitPricing,
   UnitPricingMap
 } from './types';
@@ -24,7 +25,7 @@ import {
   updateDoc,
   where
 } from '@angular/fire/firestore';
-import {Auth, user} from '@angular/fire/auth';
+import {Auth} from '@angular/fire/auth';
 
 @Injectable({
   providedIn: 'root',
@@ -36,6 +37,7 @@ export class DataService {
   bookers$: Observable<Booker[]>;
   permissions$: Observable<Permissions>;
   pricingTiers$: Observable<PricingTierMap>;
+  reservationRoundsConfig$: Observable<ReservationRoundsConfig>;
   reservations$: Observable<Reservation[]>;
   units$: Observable<BookableUnit[]>;
   unitPricing$: Observable<UnitPricingMap>;
@@ -75,6 +77,12 @@ export class DataService {
           }, {} as { [key: string]: PricingTier });
         }
       )
+    );
+
+    const reservationRoundsCollection = collection(firestore, 'reservationRounds');
+    const reservationRoundsQuery = query(reservationRoundsCollection, where('year', '==', this.configYear), limit(1));
+    this.reservationRoundsConfig$ = collectionData(reservationRoundsQuery).pipe(
+      map((it) => it[0] as ReservationRoundsConfig),
     );
 
     this.reservationsCollection = collection(firestore, 'reservations').withConverter<Reservation>({

--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -33,16 +33,15 @@ export class ReservationRoundsService {
   }
 
   definitionsToRounds(roundsConfig: ReservationRoundsConfig): ReservationRound[] {
-    const firstStartDate = DateTime.fromISO(roundsConfig.startDate);
-    let previousEndDate = firstStartDate;
+    let previousEndDate = DateTime.fromISO(roundsConfig.startDate);
 
     return roundsConfig.rounds.map(round => {
       const roundStart = previousEndDate;
-      if (round.durationWeeks && round.bookerOrder?.length) {
+      if (round.durationWeeks && round.subRoundBookerIds?.length) {
         throw new Error(`Round #${round.position} "${round.name}" cannot have both durationWeeks and bookerOrder`);
       }
 
-      const durationWeeks = round.durationWeeks || round.bookerOrder?.length;
+      const durationWeeks = round.durationWeeks || round.subRoundBookerIds?.length;
       if (!durationWeeks || durationWeeks < 1) {
         throw new Error(`Round #${round.position} "${round.name}" must have durationWeeks or bookerOrder`);
       }
@@ -54,7 +53,7 @@ export class ReservationRoundsService {
         position: round.position,
         startDate: roundStart,
         endDate: roundEnd,
-        bookerOrder: round.bookerOrder || [],
+        subRoundBookerIds: round.subRoundBookerIds || [],
       };
     });
   }

--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -1,0 +1,39 @@
+import {Injectable} from '@angular/core';
+import {ReservationRound, ReservationRoundsConfig} from '../types';
+import {map, Observable} from 'rxjs';
+import {DataService} from '../data-service';
+import {DateTime} from 'luxon';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class ReservationRoundsService {
+  reservationRoundsConfig$: Observable<ReservationRoundsConfig>;
+  reservationRounds$: Observable<ReservationRound[]>;
+
+  constructor(private readonly dataService: DataService) {
+    this.reservationRoundsConfig$ = this.dataService.reservationRoundsConfig$;
+    this.reservationRounds$ = this.reservationRoundsConfig$.pipe(
+      map(config => this.definitionsToRounds(config))
+    );
+  }
+
+  definitionsToRounds(roundsConfig: ReservationRoundsConfig): ReservationRound[] {
+    const firstStartDate = DateTime.fromISO(roundsConfig.startDate);
+    let previousEndDate = firstStartDate;
+
+    return roundsConfig.rounds.map(round => {
+      const roundStart = previousEndDate;
+      const durationWeeks = round.durationWeeks || round.bookerOrder?.length || 0;
+      const roundEnd = roundStart.plus({days: durationWeeks * 7 - 1});
+      previousEndDate = roundEnd.plus({days: 1});
+      return {
+        name: round.name,
+        position: round.position,
+        startDate: roundStart,
+        endDate: roundEnd,
+        bookerOrder: round.bookerOrder || [],
+      };
+    });
+  }
+}

--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -24,7 +24,15 @@ export class ReservationRoundsService {
 
     return roundsConfig.rounds.map(round => {
       const roundStart = previousEndDate;
-      const durationWeeks = round.durationWeeks || round.bookerOrder?.length || 0;
+      if (round.durationWeeks && round.bookerOrder?.length) {
+        throw new Error(`Round #${round.position} "${round.name}" cannot have both durationWeeks and bookerOrder`);
+      }
+
+      const durationWeeks = round.durationWeeks || round.bookerOrder?.length;
+      if (!durationWeeks || durationWeeks < 1) {
+        throw new Error(`Round #${round.position} "${round.name}" must have durationWeeks or bookerOrder`);
+      }
+
       const roundEnd = roundStart.plus({days: durationWeeks * 7 - 1});
       previousEndDate = roundEnd.plus({days: 1});
       return {

--- a/hosting/src/app/reservations/round-config.component.html
+++ b/hosting/src/app/reservations/round-config.component.html
@@ -1,0 +1,20 @@
+<div class="round-config">
+  <ul>
+    <li *ngFor="let round of rounds()">
+      @if (round.bookerOrder.length > 0) {
+        Round {{ round.name }}
+        <ul>
+          @for (bookerId of round.bookerOrder; track bookerId; let i = $index) {
+            <li>
+              {{ offsetDate(round.startDate, i) | shortDate }}
+              – {{ offsetDate(round.startDate, i + 1).plus({days: -1}) | shortDate }}:
+              {{ bookerFor(bookerId)?.name || 'unknown' }}
+            </li>
+          }
+        </ul>
+      } @else {
+        Round {{ round.name }}: {{ round.startDate | shortDate }} – {{ round.endDate | shortDate }}
+      }
+    </li>
+  </ul>
+</div>

--- a/hosting/src/app/reservations/round-config.component.html
+++ b/hosting/src/app/reservations/round-config.component.html
@@ -1,10 +1,10 @@
 <div class="round-config">
   <ul>
     <li *ngFor="let round of rounds()">
-      @if (round.bookerOrder.length > 0) {
+      @if (round.subRoundBookerIds.length > 0) {
         Round {{ round.name }}
         <ul>
-          @for (bookerId of round.bookerOrder; track bookerId; let i = $index) {
+          @for (bookerId of round.subRoundBookerIds; track bookerId; let i = $index) {
             <li>
               {{ offsetDate(round.startDate, i) | shortDate }}
               – {{ offsetDate(round.startDate, i + 1).plus({days: -1}) | shortDate }}:

--- a/hosting/src/app/reservations/round-config.component.ts
+++ b/hosting/src/app/reservations/round-config.component.ts
@@ -1,0 +1,57 @@
+import {ChangeDetectionStrategy, Component, Input, model, OnDestroy, signal, WritableSignal,} from '@angular/core';
+import {DateTime} from 'luxon';
+import {Booker, ReservationRound} from '../types';
+import {Observable, Subscription} from 'rxjs';
+import {NgForOf} from '@angular/common';
+import {ShortDate} from '../utility/short-date.pipe';
+
+@Component({
+  selector: 'round-config',
+  templateUrl: 'round-config.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    NgForOf,
+    ShortDate
+  ]
+})
+export class RoundConfigComponent implements OnDestroy {
+  _today = model(DateTime.now());
+
+  rounds: WritableSignal<ReservationRound[]> = signal([]);
+  bookers: WritableSignal<Booker[]> = signal([]);
+
+  roundsSubscription?: Subscription = undefined;
+  bookersSubscription?: Subscription = undefined;
+
+  ngOnDestroy() {
+    this.roundsSubscription?.unsubscribe();
+    this.bookersSubscription?.unsubscribe();
+  }
+
+  @Input()
+  set rounds$(value: Observable<ReservationRound[]>) {
+    this.roundsSubscription?.unsubscribe();
+
+    this.roundsSubscription = value.subscribe(rounds => {
+      this.rounds.set(rounds);
+    });
+  }
+
+  @Input()
+  set bookers$(value: Observable<Booker[]>) {
+    this.bookersSubscription?.unsubscribe();
+
+    this.bookersSubscription = value.subscribe(bookers => {
+      this.bookers.set(bookers);
+    });
+  }
+
+  bookerFor(bookerId: string): Booker | undefined {
+    return this.bookers().find(booker => booker.id === bookerId);
+  }
+
+  offsetDate(date: DateTime, weeks: number): DateTime {
+    return date.plus({days: weeks * 7});
+  }
+}

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -47,14 +47,14 @@ export interface ReservationRound {
   name: string;
   startDate: DateTime;
   endDate: DateTime;
-  bookerOrder: string[];
+  subRoundBookerIds: string[];
 }
 
 export interface ReservationRoundDefinition {
   position: number;
   name: string;
   durationWeeks?: number;
-  bookerOrder?: string[];
+  subRoundBookerIds?: string[];
 }
 
 export interface ReservationRoundsConfig {

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -1,3 +1,5 @@
+import {DateTime} from 'luxon';
+
 export interface BookableUnit {
   id: string;
   name: string;
@@ -23,6 +25,7 @@ export interface PricingTier {
   name: string;
   color: number[];
 }
+
 export type PricingTierMap = { [key: string]: PricingTier };
 
 export interface ReservableWeek {
@@ -39,6 +42,27 @@ export interface Reservation {
   bookerId: string;
 }
 
+export interface ReservationRound {
+  position: number;
+  name: string;
+  startDate: DateTime;
+  endDate: DateTime;
+  bookerOrder: string[];
+}
+
+export interface ReservationRoundDefinition {
+  position: number;
+  name: string;
+  durationWeeks?: number;
+  bookerOrder?: string[];
+}
+
+export interface ReservationRoundsConfig {
+  year: number;
+  startDate: string;
+  rounds: ReservationRoundDefinition[];
+}
+
 export interface UnitPricing {
   year: number;
   tierId: string;
@@ -46,5 +70,6 @@ export interface UnitPricing {
   weeklyPrice: number;
   dailyPrice: number;
 }
+
 // Map from unit ID to array of unit pricings (identified by tiers).
 export type UnitPricingMap = { [key: string]: UnitPricing[] };

--- a/hosting/src/app/utility/booker-picker.component.html
+++ b/hosting/src/app/utility/booker-picker.component.html
@@ -1,0 +1,13 @@
+<div class="booker-picker">
+  <div>
+    <mat-form-field>
+      <mat-label>Booking as</mat-label>
+      <mat-select [(ngModel)]="_bookerId">
+        <mat-option [value]="''">Admin</mat-option>
+        <mat-option *ngFor="let booker of bookers()" [value]="booker.id">
+          {{ booker.name }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
+  </div>
+</div>

--- a/hosting/src/app/utility/booker-picker.component.ts
+++ b/hosting/src/app/utility/booker-picker.component.ts
@@ -1,0 +1,56 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  model,
+  OnDestroy,
+  output,
+  signal,
+  WritableSignal,
+} from '@angular/core';
+import {FormsModule} from '@angular/forms';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {Booker} from '../types';
+import {Observable, Subscription} from 'rxjs';
+import {NgForOf} from '@angular/common';
+import {MatOption, MatSelect} from '@angular/material/select';
+
+@Component({
+  selector: 'booker-picker',
+  templateUrl: 'booker-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatFormField,
+    NgForOf,
+    FormsModule,
+    MatLabel,
+    MatSelect,
+    MatOption,
+  ]
+})
+export class BookerPickerComponent implements OnDestroy {
+  bookerId = output<string>();
+  _bookerId = model('');
+  bookers: WritableSignal<Booker[]> = signal([]);
+
+  bookersSubscription?: Subscription = undefined;
+
+  constructor() {
+    this._bookerId.subscribe(id => {
+      this.bookerId.emit(id);
+    })
+  }
+
+  ngOnDestroy() {
+    this.bookersSubscription?.unsubscribe();
+  }
+
+  @Input()
+  set bookers$(value: Observable<Booker[]>) {
+    this.bookersSubscription?.unsubscribe();
+    this.bookersSubscription = value.subscribe(bookers => {
+      this.bookers.set(bookers);
+    });
+  }
+}

--- a/hosting/src/app/utility/dialog-service.ts
+++ b/hosting/src/app/utility/dialog-service.ts
@@ -2,11 +2,11 @@ import {MatDialog, MatDialogConfig, MatDialogRef} from '@angular/material/dialog
 import {ComponentType} from '@angular/cdk/overlay';
 import {Injectable, TemplateRef} from '@angular/core';
 
-// Adapted from Abhinav Kumar: https://stackoverflow.com/a/79210442/211771
 @Injectable({
   providedIn: 'root',
 })
 export class DialogService extends MatDialog {
+  // Adapted from Abhinav Kumar: https://stackoverflow.com/a/79210442/211771
   override open<T, D = any, R = any>(component: ComponentType<T> | TemplateRef<T>, config?: MatDialogConfig<D>): MatDialogRef<T, R> {
     const activeElement = document.activeElement as HTMLElement;
     if (activeElement) {

--- a/hosting/src/app/utility/today-picker.component.html
+++ b/hosting/src/app/utility/today-picker.component.html
@@ -1,0 +1,11 @@
+<div class="today-picker">
+  <div>
+    <mat-form-field>
+      <mat-label>Admin today override</mat-label>
+      <input matInput [matDatepicker]="todayPicker"
+             [(ngModel)]="today" readonly/>
+      <mat-datepicker-toggle matIconSuffix [for]="todayPicker"></mat-datepicker-toggle>
+      <mat-datepicker #todayPicker></mat-datepicker>
+    </mat-form-field>
+  </div>
+</div>

--- a/hosting/src/app/utility/today-picker.component.ts
+++ b/hosting/src/app/utility/today-picker.component.ts
@@ -1,0 +1,38 @@
+import {ChangeDetectionStrategy, Component, inject, Input, model,} from '@angular/core';
+import {DateTime} from 'luxon';
+import {FormsModule} from '@angular/forms';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput} from '@angular/material/input';
+import {TodayService} from './today-service';
+
+@Component({
+  selector: 'today-picker',
+  templateUrl: 'today-picker.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    FormsModule,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatFormField,
+    MatInput,
+    MatLabel,
+    MatSuffix
+  ]
+})
+export class TodayPicker {
+  _today = model(DateTime.now());
+  todayService = inject(TodayService);
+
+  @Input()
+  set today(value: DateTime) {
+    this._today.set(value);
+    this.todayService.today = value;
+  }
+
+  get today() {
+    return this._today();
+  }
+}

--- a/hosting/src/app/utility/today-service.ts
+++ b/hosting/src/app/utility/today-service.ts
@@ -1,0 +1,18 @@
+import {Injectable, signal, Signal, WritableSignal} from '@angular/core';
+import {DateTime} from 'luxon';
+
+// Adapted from Abhinav Kumar: https://stackoverflow.com/a/79210442/211771
+@Injectable({
+  providedIn: 'root',
+})
+export class TodayService {
+  _today: WritableSignal<DateTime> = signal(DateTime.now());
+
+  set today(value: DateTime) {
+    this._today.set(value);
+  }
+
+  get today(): Signal<DateTime> {
+    return this._today;
+  }
+}

--- a/hosting/src/app/utility/today-service.ts
+++ b/hosting/src/app/utility/today-service.ts
@@ -1,7 +1,6 @@
 import {Injectable, signal, Signal, WritableSignal} from '@angular/core';
 import {DateTime} from 'luxon';
 
-// Adapted from Abhinav Kumar: https://stackoverflow.com/a/79210442/211771
 @Injectable({
   providedIn: 'root',
 })

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -33,12 +33,14 @@
           }
         </div>
       } @else {
-        <div class="add-button">
-          <button mat-icon-button aria-label="Add reservation"
-                  (click)="addReservation(unit, weekRow.pricingTier, weekRow.startDate, weekRow.endDate)">
-            <mat-icon class="material-icons-outlined">add_box</mat-icon>
-          </button>
-        </div>
+        @if (canAddReservation()) {
+          <div class="add-button">
+            <button mat-icon-button aria-label="Add reservation"
+                    (click)="addReservation(unit, weekRow.pricingTier, weekRow.startDate, weekRow.endDate)">
+              <mat-icon class="material-icons-outlined">add_box</mat-icon>
+            </button>
+          </div>
+        }
       }
     </td>
     <td mat-footer-cell *matFooterCellDef>

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -40,6 +40,7 @@ import {ANIMATION_SETTINGS} from './app.config';
 import {ErrorDialog} from './utility/error-dialog.component';
 import {CurrencyPipe} from './utility/currency-pipe';
 import {Auth} from '@angular/fire/auth';
+import {ReservationRoundsService} from './reservations/reservation-rounds-service';
 
 interface WeekRow {
   startDate: DateTime;
@@ -89,11 +90,11 @@ export class WeekTableComponent {
   private readonly auth = inject(Auth);
   private readonly dataService = inject(DataService);
   private readonly dialog = inject(MatDialog);
+  private readonly reservationsRoundsService = inject(ReservationRoundsService);
 
   // Input fields
   private _bookers: Booker[] = [];
   private _currentBooker: Booker | undefined;
-  private _currentRound: ReservationRound | undefined;
   private _reservations: Reservation[] = [];
   private _permissions: Permissions = {adminUserIds: []};
   private _pricingTiers: PricingTierMap = {};
@@ -169,11 +170,6 @@ export class WeekTableComponent {
 
   @Input() set currentBooker(value: Booker | undefined) {
     this._currentBooker = value;
-    this.buildTableRows()
-  }
-
-  @Input() set currentRound(value: ReservationRound | undefined) {
-    this._currentRound = value;
     this.buildTableRows()
   }
 
@@ -255,6 +251,17 @@ export class WeekTableComponent {
       return false;
     }
     return this._permissions.adminUserIds.includes(currentUser);
+  }
+
+  canAddReservation(): boolean {
+    if (this.isAdmin()) {
+      return true;
+    }
+    const currentBooker = this._currentBooker;
+    const currentRound = this.reservationsRoundsService.currentRound();
+    const currentSubRoundBooker = this.reservationsRoundsService.currentSubRoundBooker();
+
+    return !!currentRound && (!currentSubRoundBooker || currentSubRoundBooker.id === currentBooker?.id);
   }
 
   canEditReservation(reservation: WeekReservation): boolean {

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -26,6 +26,7 @@ import {
   PricingTierMap,
   ReservableWeek,
   Reservation,
+  ReservationRound,
   UnitPricing,
   UnitPricingMap
 } from './types';
@@ -92,6 +93,7 @@ export class WeekTableComponent {
   // Input fields
   private _bookers: Booker[] = [];
   private _currentBooker: Booker | undefined;
+  private _currentRound: ReservationRound | undefined;
   private _reservations: Reservation[] = [];
   private _permissions: Permissions = {adminUserIds: []};
   private _pricingTiers: PricingTierMap = {};
@@ -167,6 +169,11 @@ export class WeekTableComponent {
 
   @Input() set currentBooker(value: Booker | undefined) {
     this._currentBooker = value;
+    this.buildTableRows()
+  }
+
+  @Input() set currentRound(value: ReservationRound | undefined) {
+    this._currentRound = value;
     this.buildTableRows()
   }
 

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -242,6 +242,11 @@ export class WeekTableComponent {
 
   isAdmin(): boolean {
     const currentUser = this.auth.currentUser?.uid || '<nobody>';
+    // There is no admin booker. If one is set (whether as an override, or
+    // otherwise) don't set the admin status.
+    if (this._currentBooker?.id) {
+      return false;
+    }
     return this._permissions.adminUserIds.includes(currentUser);
   }
 

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -103,7 +103,7 @@ export class WeekTableComponent {
   tableRows$: Observable<WeekRow[]> = of([])
   displayedColumns: string[] = [];
 
-  buildTableRows(): Observable<WeekRow[]> {
+  buildTableRows() {
     const currentBooker = this._currentBooker;
     const weeks = this._weeks;
     const units = this._units;
@@ -116,11 +116,12 @@ export class WeekTableComponent {
     // Don't render table rows until all data is available.
     // Exception: allow no current booker if admin.
     if (!weeks.length || !(currentBooker || this.isAdmin()) || !units.length || !permissions || !Object.keys(pricingTiers).length || !reservations.length || !bookers.length || !Object.keys(unitPricing).length) {
-      return of([]);
+      this.tableRows$ = of([]);
+      return;
     }
 
     this.displayedColumns = ['week', ...units.map(unit => unit.name)];
-    return of(
+    this.tableRows$ = of(
       weeks.map(week => {
         const startDate = DateTime.fromISO(week.startDate);
         const endDate = startDate.plus({days: 7});
@@ -161,7 +162,7 @@ export class WeekTableComponent {
   @Input()
   set bookers(value: Booker[]) {
     this._bookers = value;
-    this.tableRows$ = this.buildTableRows();
+    this.buildTableRows();
   }
 
   @Input() set currentBooker(value: Booker | undefined) {
@@ -172,7 +173,7 @@ export class WeekTableComponent {
   @Input()
   set units(value: BookableUnit[]) {
     this._units = value;
-    this.tableRows$ = this.buildTableRows();
+    this.buildTableRows();
   }
 
   get units() {
@@ -182,7 +183,7 @@ export class WeekTableComponent {
   @Input()
   set weeks(value: ReservableWeek[]) {
     this._weeks = value;
-    this.tableRows$ = this.buildTableRows();
+    this.buildTableRows();
   }
 
   @Input()
@@ -194,7 +195,7 @@ export class WeekTableComponent {
   @Input()
   set pricingTiers(value: PricingTierMap) {
     this._pricingTiers = value;
-    this.tableRows$ = this.buildTableRows();
+    this.buildTableRows();
   }
 
   get pricingTiers() {
@@ -204,13 +205,13 @@ export class WeekTableComponent {
   @Input()
   set reservations(value: Reservation[]) {
     this._reservations = value;
-    this.tableRows$ = this.buildTableRows();
+    this.buildTableRows();
   }
 
   @Input()
   set unitPricing(value: UnitPricingMap) {
     this._unitPricing = value;
-    this.tableRows$ = this.buildTableRows();
+    this.buildTableRows();
   }
 
   // Helper functions


### PR DESCRIPTION
Fixes #34 

Commentary: I really enjoyed using signals more than observables. It's much easier for using a variable both in the typescript & the template, and knowing the state will update appropriately.

A lot in this one–

## 1. Introduce admin overrides for today + who's booking. This is a debugging tool to preview the app at future dates and for a user (without needing to log in as them).

<img width="294" alt="Screenshot 2024-12-30 at 10 04 34 PM" src="https://github.com/user-attachments/assets/20a1d264-ecad-4c52-85b5-47481fd2233b" />

## 2. Display rounds + subrounds at footer of the page.

<img width="300" alt="Screenshot 2024-12-30 at 10 04 21 PM" src="https://github.com/user-attachments/assets/dced021a-41c9-4ae9-8682-026b54ffde54" />

## 3. Only allow adding reservations if the round allows it.

Admin can always add:

<img width="1216" alt="Screenshot 2024-12-30 at 10 05 17 PM" src="https://github.com/user-attachments/assets/213474b2-eba4-4c99-893f-cc3b68bd75fe" />

Carl can add for 1st subround of round A:

<img width="1230" alt="Screenshot 2024-12-30 at 10 05 42 PM" src="https://github.com/user-attachments/assets/918ab71f-98c8-407d-8867-5a212425eabd" />

But not the second (which is Fran's):

<img width="1195" alt="Screenshot 2024-12-30 at 10 06 01 PM" src="https://github.com/user-attachments/assets/552348e5-8227-4583-b1f2-eceb660fcd45" />

Carl can book again from the 2nd round on

<img width="1191" alt="Screenshot 2024-12-30 at 10 06 40 PM" src="https://github.com/user-attachments/assets/13fd4a55-bcfb-4807-9594-34f37990ed0f" />

But not after the booking rounds end:

<img width="1204" alt="Screenshot 2024-12-30 at 10 07 02 PM" src="https://github.com/user-attachments/assets/8914179d-8e7d-4588-897d-06800ca9b28a" />


