### PR TITLE
Add round week limit

### DIFF
--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -3,7 +3,7 @@
   <p>Today is: {{ today().toISODate() }}</p>
   @if (isAdmin()) {
     <today-picker [today]="today()"></today-picker>
-    <booker-picker (bookerId)="bookerIdOverride.set($event)" [bookers$]="bookers$"></booker-picker>
+    <booker-picker (bookerId)="bookerIdOverride.set($event)" [bookers]="bookers"></booker-picker>
   }
   <app-auth/>
   @if (user$ | async) {
@@ -16,8 +16,13 @@
         ({{ reservationRoundsService.currentSubRoundBooker()?.name }})
       }
     </mat-chip>
+    @for (item of (dataService.reservationWeekCounts$ | async) || {} | keyvalue; track [item.key, item.value]) {
+      <mat-chip>
+        {{ bookerName(item.key) }}: {{ item.value }} weeks booked
+      </mat-chip>
+    }
     <week-table
-      [bookers]="(bookers$ | async) || []"
+      [bookers]="bookers()"
       [currentBooker]="(currentBooker$ | async) || undefined"
       [weeks]="(weeks$ | async) || []"
       [units]="(units$ | async) || []"
@@ -26,7 +31,7 @@
       [reservations]="(reservations$ | async) || []"
       [unitPricing]="(unitPricing$ | async) || {}"
     />
-    <round-config [rounds$]="reservationRounds$" [bookers$]="bookers$"/>
+    <round-config [rounds$]="reservationRounds$" [bookers]="bookers"/>
   } @else {
     <p>
       Please log in

--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -7,20 +7,22 @@
   }
   <app-auth/>
   @if (user$ | async) {
-    <mat-chip>
-      Year: {{ dataService.configYear }}
-    </mat-chip>
-    <mat-chip>
-      Current round: {{ reservationRoundsService.currentRound()?.name || 'none' }}
-      @if (reservationRoundsService.currentSubRoundBooker()) {
-        ({{ reservationRoundsService.currentSubRoundBooker()?.name }})
-      }
-    </mat-chip>
-    @for (item of (dataService.reservationWeekCounts$ | async) || {} | keyvalue; track [item.key, item.value]) {
+    <mat-chip-set>
       <mat-chip>
-        {{ bookerName(item.key) }}: {{ item.value }} weeks booked
+        Year: {{ dataService.configYear }}
       </mat-chip>
-    }
+      <mat-chip>
+        Current round: {{ reservationRoundsService.currentRound()?.name || 'none' }}
+        @if (reservationRoundsService.currentSubRoundBooker()) {
+          ({{ reservationRoundsService.currentSubRoundBooker()?.name }})
+        }
+      </mat-chip>
+      @for (item of (dataService.reservationWeekCounts$ | async) || {} | keyvalue; track [item.key, item.value]) {
+        <mat-chip>
+          {{ bookerName(item.key) }}: {{ item.value }} weeks booked
+        </mat-chip>
+      }
+    </mat-chip-set>
     <week-table
       [bookers]="bookers()"
       [currentBooker]="(currentBooker$ | async) || undefined"

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -1,7 +1,7 @@
 import {Component, inject, OnDestroy, signal, Signal, WritableSignal} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
 import {Firestore} from '@angular/fire/firestore';
-import {AsyncPipe} from '@angular/common';
+import {AsyncPipe, KeyValuePipe} from '@angular/common';
 import {AuthComponent} from './auth/auth.component';
 import {Auth, User, user} from '@angular/fire/auth';
 import {combineLatest, map, Observable} from 'rxjs';
@@ -39,6 +39,7 @@ import {MatChip} from '@angular/material/chips';
     RoundConfigComponent,
     BookerPickerComponent,
     MatChip,
+    KeyValuePipe,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
@@ -58,7 +59,7 @@ export class AppComponent implements OnDestroy {
 
   title = 'Reservations-App';
 
-  bookers$: Observable<Booker[]>;
+  bookers: Signal<Booker[]>;
   currentBooker$: Observable<Booker | undefined>;
   weeks$: Observable<ReservableWeek[]>;
   reservationRounds$: Observable<ReservationRound[]>;
@@ -74,7 +75,7 @@ export class AppComponent implements OnDestroy {
 
   constructor(dataService: DataService, reservationRoundsService: ReservationRoundsService) {
     this.dataService = dataService;
-    this.bookers$ = dataService.bookers$;
+    this.bookers = dataService.bookers;
     this.permissions$ = dataService.permissions$;
     this.pricingTiers$ = dataService.pricingTiers$;
     this.reservationRounds$ = reservationRoundsService.reservationRounds$;
@@ -83,7 +84,7 @@ export class AppComponent implements OnDestroy {
     this.units$ = dataService.units$;
     this.weeks$ = dataService.weeks$;
 
-    this.currentBooker$ = combineLatest([dataService.bookers$, this.user$, toObservable(this.bookerIdOverride)]).pipe(
+    this.currentBooker$ = combineLatest([toObservable(dataService.bookers), this.user$, toObservable(this.bookerIdOverride)]).pipe(
       map(([bookers, user, bookerIdOverride]) => {
         return bookerIdOverride?.length ?
           bookers.find(booker => booker.id === bookerIdOverride) :
@@ -107,5 +108,9 @@ export class AppComponent implements OnDestroy {
   ngOnDestroy() {
     this.permissionsSubscription.unsubscribe();
     this.currentUserSubscription.unsubscribe();
+  }
+
+  bookerName(bookerId: string): string {
+    return this.bookers().find(booker => booker.id === bookerId)?.name || '';
   }
 }

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -24,7 +24,7 @@ import {ReservationRoundsService} from './reservations/reservation-rounds-servic
 import {RoundConfigComponent} from './reservations/round-config.component';
 import {BookerPickerComponent} from './utility/booker-picker.component';
 import {toObservable} from '@angular/core/rxjs-interop';
-import {MatChip} from '@angular/material/chips';
+import {MatChip, MatChipSet} from '@angular/material/chips';
 
 
 @Component({
@@ -40,6 +40,7 @@ import {MatChip} from '@angular/material/chips';
     BookerPickerComponent,
     MatChip,
     KeyValuePipe,
+    MatChipSet,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'

--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -78,6 +78,7 @@ export class ReservationRoundsService implements OnDestroy {
         startDate: roundStart,
         endDate: roundEnd,
         subRoundBookerIds: round.subRoundBookerIds || [],
+        bookedWeeksLimit: round.bookedWeeksLimit || 0,
       };
     });
   }

--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -35,7 +35,7 @@ export class ReservationRoundsService implements OnDestroy {
       }
     );
 
-    this.currentSubRoundBookerSubscription = combineLatest([toObservable(this.today), toObservable(this.currentRound), this.dataService.bookers$]).subscribe(
+    this.currentSubRoundBookerSubscription = combineLatest([toObservable(this.today), toObservable(this.currentRound), toObservable(this.dataService.bookers)]).subscribe(
       ([today, round, bookers]) => {
         if (!round || !round.subRoundBookerIds.length) {
           this.currentSubRoundBooker.set(undefined);

--- a/hosting/src/app/reservations/round-config.component.html
+++ b/hosting/src/app/reservations/round-config.component.html
@@ -1,20 +1,21 @@
 <div class="round-config">
   <ul>
     <li *ngFor="let round of rounds()">
-      @if (round.subRoundBookerIds.length > 0) {
-        Round {{ round.name }}
-        <ul>
-          @for (bookerId of round.subRoundBookerIds; track bookerId; let i = $index) {
-            <li>
-              {{ offsetDate(round.startDate, i) | shortDate }}
-              – {{ offsetDate(round.startDate, i + 1).plus({days: -1}) | shortDate }}:
-              {{ bookerFor(bookerId)?.name || 'unknown' }}
-            </li>
-          }
-        </ul>
-      } @else {
-        Round {{ round.name }}: {{ round.startDate | shortDate }} – {{ round.endDate | shortDate }}
-      }
+      Round {{ round.name }}: {{ round.startDate | shortDate }} – {{ round.endDate | shortDate }}
+      <ul>
+        @for (bookerId of round.subRoundBookerIds; track bookerId; let i = $index) {
+          <li>
+            {{ offsetDate(round.startDate, i) | shortDate }}
+            – {{ offsetDate(round.startDate, i + 1).plus({days: -1}) | shortDate }}:
+            {{ bookerFor(bookerId)?.name || 'unknown' }}
+          </li>
+        }
+        @if (round.bookedWeeksLimit > 0 ) {
+          <li>
+            Booking limit: {{ round.bookedWeeksLimit }} weeks
+          </li>
+        }
+      </ul>
     </li>
   </ul>
 </div>

--- a/hosting/src/app/reservations/round-config.component.ts
+++ b/hosting/src/app/reservations/round-config.component.ts
@@ -1,4 +1,13 @@
-import {ChangeDetectionStrategy, Component, Input, model, OnDestroy, signal, WritableSignal,} from '@angular/core';
+import {
+  ChangeDetectionStrategy,
+  Component,
+  Input,
+  model,
+  OnDestroy,
+  Signal,
+  signal,
+  WritableSignal,
+} from '@angular/core';
 import {DateTime} from 'luxon';
 import {Booker, ReservationRound} from '../types';
 import {Observable, Subscription} from 'rxjs';
@@ -19,14 +28,13 @@ export class RoundConfigComponent implements OnDestroy {
   _today = model(DateTime.now());
 
   rounds: WritableSignal<ReservationRound[]> = signal([]);
-  bookers: WritableSignal<Booker[]> = signal([]);
+  @Input()
+  bookers: Signal<Booker[]> = signal([]);
 
   roundsSubscription?: Subscription = undefined;
-  bookersSubscription?: Subscription = undefined;
 
   ngOnDestroy() {
     this.roundsSubscription?.unsubscribe();
-    this.bookersSubscription?.unsubscribe();
   }
 
   @Input()
@@ -35,15 +43,6 @@ export class RoundConfigComponent implements OnDestroy {
 
     this.roundsSubscription = value.subscribe(rounds => {
       this.rounds.set(rounds);
-    });
-  }
-
-  @Input()
-  set bookers$(value: Observable<Booker[]>) {
-    this.bookersSubscription?.unsubscribe();
-
-    this.bookersSubscription = value.subscribe(bookers => {
-      this.bookers.set(bookers);
     });
   }
 

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -48,6 +48,7 @@ export interface ReservationRound {
   startDate: DateTime;
   endDate: DateTime;
   subRoundBookerIds: string[];
+  bookedWeeksLimit: number;
 }
 
 export interface ReservationRoundDefinition {
@@ -55,6 +56,7 @@ export interface ReservationRoundDefinition {
   name: string;
   durationWeeks?: number;
   subRoundBookerIds?: string[];
+  bookedWeeksLimit?: number;
 }
 
 export interface ReservationRoundsConfig {

--- a/hosting/src/app/utility/booker-picker.component.ts
+++ b/hosting/src/app/utility/booker-picker.component.ts
@@ -5,13 +5,14 @@ import {
   model,
   OnDestroy,
   output,
+  OutputRefSubscription,
+  Signal,
   signal,
   WritableSignal,
 } from '@angular/core';
 import {FormsModule} from '@angular/forms';
 import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {Booker} from '../types';
-import {Observable, Subscription} from 'rxjs';
 import {NgForOf} from '@angular/common';
 import {MatOption, MatSelect} from '@angular/material/select';
 
@@ -32,25 +33,18 @@ import {MatOption, MatSelect} from '@angular/material/select';
 export class BookerPickerComponent implements OnDestroy {
   bookerId = output<string>();
   _bookerId = model('');
-  bookers: WritableSignal<Booker[]> = signal([]);
+  @Input()
+  bookers: Signal<Booker[]> = signal([]);
 
-  bookersSubscription?: Subscription = undefined;
+  bookerSubscription?: OutputRefSubscription;
 
   constructor() {
-    this._bookerId.subscribe(id => {
+    this.bookerSubscription = this._bookerId.subscribe(id => {
       this.bookerId.emit(id);
     })
   }
 
   ngOnDestroy() {
-    this.bookersSubscription?.unsubscribe();
-  }
-
-  @Input()
-  set bookers$(value: Observable<Booker[]>) {
-    this.bookersSubscription?.unsubscribe();
-    this.bookersSubscription = value.subscribe(bookers => {
-      this.bookers.set(bookers);
-    });
+    this.bookerSubscription?.unsubscribe();
   }
 }

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -261,7 +261,13 @@ export class WeekTableComponent {
     const currentRound = this.reservationsRoundsService.currentRound();
     const currentSubRoundBooker = this.reservationsRoundsService.currentSubRoundBooker();
 
-    return !!currentRound && (!currentSubRoundBooker || currentSubRoundBooker.id === currentBooker?.id);
+    const bookableRound = !!currentRound && (!currentSubRoundBooker || currentSubRoundBooker.id === currentBooker?.id);
+
+    const applicableBookingLimit = currentRound?.bookedWeeksLimit || 0;
+    const bookedWeeks = this._reservations.filter(reservation => reservation.bookerId === currentBooker?.id).length;
+    const underBookingLimit = bookedWeeks < applicableBookingLimit;
+
+    return bookableRound && underBookingLimit;
   }
 
   canEditReservation(reservation: WeekReservation): boolean {


### PR DESCRIPTION
Fixes #37

Adds a booking limit to the round configuration (default: no limit).

<img width="318" alt="Screenshot 2024-12-30 at 11 02 17 PM" src="https://github.com/user-attachments/assets/3b1884c3-e527-42f1-8a0e-197ee72c3d9c" />

When in a limited round, Fran's Family can still book with 7 reservations:

<img width="1223" alt="Screenshot 2024-12-30 at 11 02 44 PM" src="https://github.com/user-attachments/assets/fffee6d8-a21e-46d2-a70a-97c1271940ac" />

but after making the 8th, no longer:

<img width="1218" alt="Screenshot 2024-12-30 at 11 03 21 PM" src="https://github.com/user-attachments/assets/2f0de3d7-930c-48ac-870c-ab13b82766b6" />

If we move into the next round (without limits) we can book again:

<img width="1223" alt="Screenshot 2024-12-30 at 11 03 42 PM" src="https://github.com/user-attachments/assets/cb7d7909-953b-47d6-a87c-cf457487e194" />

Note that Fran's Family may delete reservations to get under the limit again.