### PR TITLE
Fix log in/out state management

### DIFF
--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -25,7 +25,7 @@
     </mat-chip-set>
     <week-table
       [bookers]="bookers()"
-      [currentBooker]="(currentBooker$ | async) || undefined"
+      [currentBooker]="currentBooker()"
       [weeks]="(weeks$ | async) || []"
       [units]="(units$ | async) || []"
       [permissions]="(permissions$ | async) || {adminUserIds: []}"


### PR DESCRIPTION
The app wasn't managing state correctly for log in/out events. The problem is errors would disconnect pipes and subscriptions.

Converting several elements to signals made this easier to wrangle.

Fixes #39 