### PR TITLE
Allow daily reservations

### DIFF
--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -84,6 +84,7 @@ export class ReservationRoundsService implements OnDestroy {
         endDate: roundEnd,
         subRoundBookerIds: round.subRoundBookerIds || [],
         bookedWeeksLimit: round.bookedWeeksLimit || 0,
+        allowDailyReservations: !!round.allowDailyReservations,
       };
     });
   }

--- a/hosting/src/app/reservations/reserve-dialog.component.html
+++ b/hosting/src/app/reservations/reserve-dialog.component.html
@@ -12,25 +12,34 @@
       <input matInput value="{{unit.name}}" readonly="true"/>
     </mat-form-field>
   </div>
+  @if (canBookDaily()) {
+    <div>
+      <mat-button-toggle-group
+        [(ngModel)]="bookingDaily"
+        aria-label="Booking daily"
+      >
+        <mat-button-toggle [value]="false" [disabled]="false && blockedDates.size > 0">Weekly</mat-button-toggle>
+        <mat-button-toggle [value]="true">Daily</mat-button-toggle>
+      </mat-button-toggle-group>
+      <div>&nbsp;</div>
+    </div>
+  }
   <div>
     <mat-form-field>
-      <mat-label>Start date</mat-label>
-      <input matInput [min]="weekStartDate" [max]="reservationEndDate()" [matDatepicker]="startPicker"
-             [(ngModel)]="reservationStartDate" [readonly]="!canEditDates()"/>
-      <mat-datepicker-toggle matIconSuffix [for]="startPicker" [disabled]="!canEditDates()"></mat-datepicker-toggle>
+      <mat-label>Check-in</mat-label>
+      <input matInput
+             [min]="weekStartDate"
+             [max]="bookingDaily() ? weekEndDate.plus({days: -1}) : weekStartDate"
+             [matDatepicker]="startPicker"
+             [(ngModel)]="reservationStartDate" [readonly]="!bookingDaily()" [matDatepickerFilter]="isDateAvailable"/>
+      <mat-datepicker-toggle matIconSuffix [for]="startPicker" [disabled]="!bookingDaily()"></mat-datepicker-toggle>
       <mat-datepicker #startPicker></mat-datepicker>
       <mat-error>Invalid date</mat-error>
     </mat-form-field>
+    <div>Check-out: {{ reservationEndDate() | shortDate }}</div>
+    <div>&nbsp;</div>
   </div>
   <div>
-    <mat-form-field>
-      <mat-label>End date</mat-label>
-      <input matInput [min]="reservationStartDate().plus({days: 1})" [max]="weekEndDate" [matDatepicker]="endPicker"
-             [(ngModel)]="reservationEndDate" [readonly]="!canEditDates()"/>
-      <mat-datepicker-toggle matIconSuffix [for]="endPicker" [disabled]="!canEditDates()"></mat-datepicker-toggle>
-      <mat-datepicker #endPicker></mat-datepicker>
-      <mat-error>Invalid date</mat-error>
-    </mat-form-field>
   </div>
   <div>
     <mat-form-field>
@@ -52,6 +61,11 @@
   <div>
     Reservation cost: {{ reservationCost() | currency }}
   </div>
+  @if (reservationConflicts()) {
+    <div>
+      <mat-error>Reservation conflicts with existing reservations</mat-error>
+    </div>
+  }
 </mat-dialog-content>
 <mat-dialog-actions>
   @if (data.existingReservationId) {

--- a/hosting/src/app/reservations/reserve-dialog.component.html
+++ b/hosting/src/app/reservations/reserve-dialog.component.html
@@ -15,9 +15,9 @@
   <div>
     <mat-form-field>
       <mat-label>Start date</mat-label>
-      <input matInput [min]="weekStartDate" [max]="weekEndDate" [matDatepicker]="startPicker"
-             [(ngModel)]="reservationStartDate" readonly/>
-      <mat-datepicker-toggle matIconSuffix [for]="startPicker" disabled></mat-datepicker-toggle>
+      <input matInput [min]="weekStartDate" [max]="reservationEndDate()" [matDatepicker]="startPicker"
+             [(ngModel)]="reservationStartDate" [readonly]="!canEditDates()"/>
+      <mat-datepicker-toggle matIconSuffix [for]="startPicker" [disabled]="!canEditDates()"></mat-datepicker-toggle>
       <mat-datepicker #startPicker></mat-datepicker>
       <mat-error>Invalid date</mat-error>
     </mat-form-field>
@@ -25,9 +25,9 @@
   <div>
     <mat-form-field>
       <mat-label>End date</mat-label>
-      <input matInput [min]="weekStartDate" [max]="weekEndDate" [matDatepicker]="endPicker"
-             [(ngModel)]="reservationEndDate" readonly/>
-      <mat-datepicker-toggle matIconSuffix [for]="endPicker" disabled></mat-datepicker-toggle>
+      <input matInput [min]="reservationStartDate().plus({days: 1})" [max]="weekEndDate" [matDatepicker]="endPicker"
+             [(ngModel)]="reservationEndDate" [readonly]="!canEditDates()"/>
+      <mat-datepicker-toggle matIconSuffix [for]="endPicker" [disabled]="!canEditDates()"></mat-datepicker-toggle>
       <mat-datepicker #endPicker></mat-datepicker>
       <mat-error>Invalid date</mat-error>
     </mat-form-field>

--- a/hosting/src/app/reservations/reserve-dialog.component.ts
+++ b/hosting/src/app/reservations/reserve-dialog.component.ts
@@ -22,8 +22,10 @@ import {MatLuxonDateModule} from '@angular/material-luxon-adapter';
 import {DateTime} from 'luxon';
 import {CurrencyPipe} from "../utility/currency-pipe";
 import {MatOption, MatSelect} from '@angular/material/select';
+import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-toggle';
+import {ShortDate} from '../utility/short-date.pipe';
 
-interface ReserveDialogData {
+export interface ReserveDialogData {
   bookers: Booker[];
   unit: BookableUnit;
   tier: PricingTier;
@@ -36,6 +38,7 @@ interface ReserveDialogData {
   initialBookerId?: string;
   existingReservationId?: string;
   allowDailyReservations: boolean;
+  blockedDates: Set<string>;
 }
 
 @Component({
@@ -62,6 +65,9 @@ interface ReserveDialogData {
     CurrencyPipe,
     MatSelect,
     MatOption,
+    MatButtonToggleGroup,
+    MatButtonToggle,
+    ShortDate,
   ]
 })
 export class ReserveDialog {
@@ -74,12 +80,15 @@ export class ReserveDialog {
   reservationEndDate = model(DateTime.now());
   guestName = model('');
   bookerId = model('');
+  bookingDaily = model(false);
 
   readonly existingReservationId: string | undefined;
   readonly bookers: Booker[];
   readonly unit: BookableUnit;
   readonly tier: PricingTier;
   readonly unitPricing: UnitPricing[];
+  readonly blockedDates: Set<string> = new Set();
+  readonly isDateAvailable = this.isDateAvailableBuilder();
 
   reservation = output<Reservation>();
   deleteReservation = output<void>();
@@ -89,6 +98,7 @@ export class ReserveDialog {
     this.tier = data.tier;
     this.unitPricing = data.unitPricing;
     this.bookers = data.bookers;
+    this.blockedDates = data.blockedDates || new Set();
 
     this.weekStartDate = data.weekStartDate;
     this.weekEndDate = data.weekEndDate;
@@ -98,6 +108,26 @@ export class ReserveDialog {
     this.guestName.set(data.initialGuestName || '');
     this.bookerId.set(data.initialBookerId || (this.bookers.length == 1 ? this.bookers[0].id : ''));
     this.existingReservationId = data.existingReservationId;
+
+    this.bookingDaily.set(
+      this.reservationEndDate().diff(this.reservationStartDate(), 'days').days === 1
+    );
+
+    this.reservationStartDate.subscribe(date => {
+      if (this.bookingDaily()) {
+        this.reservationEndDate.set(date.plus({days: 1}));
+      } else {
+        this.reservationEndDate.set(date.plus({days: 7}));
+      }
+    });
+    this.bookingDaily.subscribe(daily => {
+      if (daily) {
+        this.reservationEndDate.set(this.reservationStartDate().plus({days: 1}));
+      } else {
+        this.reservationStartDate.set(this.weekStartDate);
+        this.reservationEndDate.set(this.weekEndDate);
+      }
+    });
   }
 
   reservationCost(): number | undefined {
@@ -118,8 +148,23 @@ export class ReserveDialog {
     }
   }
 
+  isDateAvailableBuilder() {
+    const _this = this;
+
+    return (date: DateTime | null) => {
+      return !!date && !_this.blockedDates.has(date.toISO()!);
+    }
+  }
+
+  reservationConflicts() {
+    const reservationLength = this.reservationEndDate().diff(this.reservationStartDate(), 'days').days;
+    const reservationDates = [...Array(reservationLength).keys()].map(offset => this.reservationStartDate().plus({days: offset}));
+    return reservationDates.some(date => !this.isDateAvailable(date));
+  }
+
   isValid(): boolean {
     return this.guestName().length > 0 &&
+      !this.reservationConflicts() &&
       this.reservationStartDate() < this.reservationEndDate() &&
       this.reservationStartDate() >= this.weekStartDate &&
       this.reservationEndDate() <= this.weekEndDate &&
@@ -143,7 +188,7 @@ export class ReserveDialog {
     }
   }
 
-  canEditDates(): boolean {
+  canBookDaily(): boolean {
     return this.data.allowDailyReservations;
   }
 }

--- a/hosting/src/app/reservations/round-config.component.html
+++ b/hosting/src/app/reservations/round-config.component.html
@@ -15,6 +15,11 @@
             Booking limit: {{ round.bookedWeeksLimit }} weeks
           </li>
         }
+        @if (round.allowDailyReservations) {
+          <li>
+            Daily reservations allowed
+          </li>
+        }
       </ul>
     </li>
   </ul>

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -49,6 +49,7 @@ export interface ReservationRound {
   endDate: DateTime;
   subRoundBookerIds: string[];
   bookedWeeksLimit: number;
+  allowDailyReservations: boolean;
 }
 
 export interface ReservationRoundDefinition {
@@ -57,6 +58,7 @@ export interface ReservationRoundDefinition {
   durationWeeks?: number;
   subRoundBookerIds?: string[];
   bookedWeeksLimit?: number;
+  allowDailyReservations?: boolean;
 }
 
 export interface ReservationRoundsConfig {

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -35,6 +35,14 @@
                       </button>
                     </span>
                   }
+                  @if (!reservation && canAddDailyReservation()) {
+                    <div class="add-button" style="float: right">
+                      <button mat-icon-button aria-label="Add reservation"
+                              (click)="addReservation(weekRow, unit, day, day.plus({days: 1}))">
+                        <mat-icon class="material-icons-outlined">add_box</mat-icon>
+                      </button>
+                    </div>
+                  }
                 </span>
                 <span matListItemLine>{{ reservation?.guestName }}</span>
                 <span>{{ bookerName(reservation?.bookerId || "") || '' }}</span>
@@ -60,7 +68,7 @@
         @if (canAddReservation()) {
           <div class="add-button">
             <button mat-icon-button aria-label="Add reservation"
-                    (click)="addReservation(unit, weekRow.pricingTier, weekRow.startDate, weekRow.endDate)">
+                    (click)="addReservation(weekRow, unit, weekRow.startDate, weekRow.endDate)">
               <mat-icon class="material-icons-outlined">add_box</mat-icon>
             </button>
           </div>

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -23,9 +23,11 @@
               Reserved by the day
             </mat-expansion-panel-header>
             <mat-list>
-              @for (reservation of unitReservations; track reservation) {
-                <mat-list-item>
-                  @if (canEditReservation(reservation)) {
+              <mat-list-item *ngFor="let day of weekDates(weekRow)">
+                @let reservation = reservationForDay(unitReservations, day);
+                <span matListItemTitle>
+                  {{ day | shortDate }}
+                  @if (!!reservation && canEditReservation(reservation)) {
                     <span style="float: right">
                       <button mat-icon-button aria-label="Edit reservation"
                               (click)="editReservation(reservation, weekRow)">
@@ -33,17 +35,10 @@
                       </button>
                     </span>
                   }
-                  <span matListItemTitle>
-                    {{ reservation.guestName }}
-                  </span>
-                  <span matListItemLine>
-                    ({{ bookerName(reservation.bookerId) || 'unknown' }})
-                  </span>
-                  <span>
-                    {{ reservation.startDate | shortDate }} – {{ reservation.endDate | shortDate }}
-                  </span>
-                </mat-list-item>
-              }
+                </span>
+                <span matListItemLine>{{ reservation?.guestName }}</span>
+                <span>{{ bookerName(reservation?.bookerId || "") || '' }}</span>
+              </mat-list-item>
             </mat-list>
           </mat-expansion-panel>
         </mat-accordion>

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -14,10 +14,39 @@
   <ng-container *ngFor="let unit of units" [matColumnDef]="unit.name">
     <th mat-header-cell *matHeaderCellDef> {{ unit.name }}</th>
     <td mat-cell *matCellDef="let weekRow">
-      @let unitReservations = weekRow.reservations[unit.id];
+      @let unitReservations = weekRow.reservations[unit.id] || [];
 
-      @if (unitReservations?.length > 1) {
-        Reserved by the day
+      @if (isReservedByDay(unitReservations)) {
+        <mat-accordion>
+          <mat-expansion-panel>
+            <mat-expansion-panel-header>
+              Reserved by the day
+            </mat-expansion-panel-header>
+            <mat-list>
+              @for (reservation of unitReservations; track reservation) {
+                <mat-list-item>
+                  @if (canEditReservation(reservation)) {
+                    <span style="float: right">
+                      <button mat-icon-button aria-label="Edit reservation"
+                              (click)="editReservation(reservation, weekRow)">
+                        <mat-icon>edit</mat-icon>
+                      </button>
+                    </span>
+                  }
+                  <span matListItemTitle>
+                    {{ reservation.guestName }}
+                  </span>
+                  <span matListItemLine>
+                    ({{ bookerName(reservation.bookerId) || 'unknown' }})
+                  </span>
+                  <span>
+                    {{ reservation.startDate | shortDate }} – {{ reservation.endDate | shortDate }}
+                  </span>
+                </mat-list-item>
+              }
+            </mat-list>
+          </mat-expansion-panel>
+        </mat-accordion>
       } @else if (unitReservations?.length === 1) {
         @let reservation = unitReservations[0];
         <div>

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -40,6 +40,8 @@ import {ErrorDialog} from './utility/error-dialog.component';
 import {CurrencyPipe} from './utility/currency-pipe';
 import {Auth} from '@angular/fire/auth';
 import {ReservationRoundsService} from './reservations/reservation-rounds-service';
+import {MatAccordion, MatExpansionPanel, MatExpansionPanelHeader} from '@angular/material/expansion';
+import {MatList, MatListItem, MatListItemLine, MatListItemTitle} from '@angular/material/list';
 
 interface WeekRow {
   startDate: DateTime;
@@ -81,6 +83,13 @@ interface WeekReservation {
     CurrencyPipe,
     MatIconButton,
     MatIcon,
+    MatAccordion,
+    MatExpansionPanel,
+    MatExpansionPanelHeader,
+    MatList,
+    MatListItem,
+    MatListItemLine,
+    MatListItemTitle,
   ],
   templateUrl: './week-table.component.html',
   styleUrl: './week-table.component.css'
@@ -232,7 +241,15 @@ export class WeekTableComponent {
     const allowDailyReservations = this.isAdmin() || this.reservationsRoundsService.currentRound()?.allowDailyReservations || false;
 
     const dialogRef = this.dialog.open(ReserveDialog, {
-      data: {unit, tier, weekStartDate, weekEndDate, unitPricing, bookers: this.availableBookers(), allowDailyReservations},
+      data: {
+        unit,
+        tier,
+        weekStartDate,
+        weekEndDate,
+        unitPricing,
+        bookers: this.availableBookers(),
+        allowDailyReservations
+      },
       ...ANIMATION_SETTINGS,
     });
 
@@ -291,6 +308,8 @@ export class WeekTableComponent {
         tier,
         weekStartDate,
         weekEndDate,
+        startDate: reservation.startDate,
+        endDate: reservation.endDate,
         unitPricing,
         bookers,
         initialGuestName: reservation.guestName,
@@ -362,6 +381,12 @@ export class WeekTableComponent {
   bookerName(bookerId: string): string | undefined {
     const booker = this._bookers().find(it => it.id === bookerId);
     return booker?.name;
+  }
+
+  isReservedByDay(reservations: WeekReservation[]): boolean {
+    return reservations?.some(reservation => {
+      return reservation.endDate.diff(reservation.startDate, 'days').days < 7;
+    });
   }
 
   rowStyle(pricingTier: PricingTier) {

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -50,8 +50,8 @@ interface WeekRow {
 
 interface WeekReservation {
   id: string;
-  startDate: Date;
-  endDate: Date;
+  startDate: DateTime;
+  endDate: DateTime;
   unit: BookableUnit;
   guestName: string;
   bookerId: string;
@@ -137,8 +137,8 @@ export class WeekTableComponent {
           const unit = units.find(unit => unit.id === reservation.unitId);
           return {
             id: reservation.id,
-            startDate: new Date(Date.parse(reservation.startDate)),
-            endDate: new Date(Date.parse(reservation.endDate)),
+            startDate: DateTime.fromISO(reservation.startDate),
+            endDate: DateTime.fromISO(reservation.endDate),
             unit,
             guestName: reservation.guestName,
             bookerId: reservation.bookerId,

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -343,6 +343,10 @@ export class WeekTableComponent {
     if (!reservation.bookerId) {
       errors.push("Booker is required.");
     }
+    const reservationLength = DateTime.fromISO(reservation.endDate).diff(DateTime.fromISO(reservation.startDate), 'days').days;
+    if (reservationLength != 1 && reservationLength != 7) {
+      errors.push("Reservation must be for 1 or 7 days.");
+    }
 
     if (errors.length) {
       this.dialog.open(ErrorDialog, {data: errors.join(' '), ...ANIMATION_SETTINGS});
@@ -383,9 +387,19 @@ export class WeekTableComponent {
     return booker?.name;
   }
 
+  weekDates(week: WeekRow): DateTime[] {
+    return [...Array(7).keys()].map((i) => week.startDate.plus({days: i}));
+  }
+
   isReservedByDay(reservations: WeekReservation[]): boolean {
     return reservations?.some(reservation => {
       return reservation.endDate.diff(reservation.startDate, 'days').days < 7;
+    });
+  }
+
+  reservationForDay(reservations: WeekReservation[], date: DateTime): WeekReservation | undefined {
+    return reservations.find(reservation => {
+      return reservation.startDate.equals(date);
     });
   }
 

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -229,10 +229,10 @@ export class WeekTableComponent {
 
   addReservation(unit: BookableUnit, tier: PricingTier, weekStartDate: DateTime, weekEndDate: DateTime) {
     const unitPricing = this._unitPricing[unit.id] || [];
-    const bookers = this._bookers;
+    const allowDailyReservations = this.isAdmin() || this.reservationsRoundsService.currentRound()?.allowDailyReservations || false;
 
     const dialogRef = this.dialog.open(ReserveDialog, {
-      data: {unit, tier, weekStartDate, weekEndDate, unitPricing, bookers: this.availableBookers()},
+      data: {unit, tier, weekStartDate, weekEndDate, unitPricing, bookers: this.availableBookers(), allowDailyReservations},
       ...ANIMATION_SETTINGS,
     });
 
@@ -283,6 +283,7 @@ export class WeekTableComponent {
     const weekEndDate = week.endDate;
     const unitPricing = this._unitPricing[unit.id] || [];
     const bookers = this.availableBookers();
+    const allowDailyReservations = this.isAdmin() || this.reservationsRoundsService.currentRound()?.allowDailyReservations || false;
 
     const dialogRef = this.dialog.open(ReserveDialog, {
       data: {
@@ -295,6 +296,7 @@ export class WeekTableComponent {
         initialGuestName: reservation.guestName,
         initialBookerId: reservation.bookerId,
         existingReservationId: reservation.id,
+        allowDailyReservations,
       },
       ...ANIMATION_SETTINGS,
     });


### PR DESCRIPTION
Fixes #41 

Allows reserving by the day, as shown here:

<img width="1360" alt="Screenshot 2024-12-31 at 7 33 57 PM" src="https://github.com/user-attachments/assets/f09a5ed1-d6b3-4b30-8fb9-301518811054" />

When expanded, the admin (or a booker when the round allows) may add daily reservations:

<img width="1392" alt="Screenshot 2024-12-31 at 7 35 31 PM" src="https://github.com/user-attachments/assets/d24fb6ea-d7c4-4fc1-a51e-6324a1a7ba27" />

Adding a reservation has a daily mode toggle:

<img width="314" alt="Screenshot 2024-12-31 at 7 36 21 PM" src="https://github.com/user-attachments/assets/41079d46-ca03-4159-9f67-08bdf7740679" />

We validate for no conflicts; if we try to switch the new daily reservation to weekly it will conflict with the existing daily reservations:

<img width="377" alt="Screenshot 2024-12-31 at 7 37 03 PM" src="https://github.com/user-attachments/assets/e5ac0b66-358f-4e4f-9a18-93e10aea49ff" />
