### PR TITLE
Choose viewing year + display grid with empty reservations

### DIFF
--- a/hosting/src/app/app.component.html
+++ b/hosting/src/app/app.component.html
@@ -7,9 +7,17 @@
   }
   <app-auth/>
   @if (user$ | async) {
+    <mat-form-field>
+      <mat-label>Viewing year</mat-label>
+      <mat-select [(ngModel)]="currentYear">
+        <mat-option *ngFor="let year of dataService.availableYears()" [value]="year">
+          {{ year }}
+        </mat-option>
+      </mat-select>
+    </mat-form-field>
     <mat-chip-set>
       <mat-chip>
-        Year: {{ dataService.configYear }}
+        Year: {{ currentYear() }}
       </mat-chip>
       <mat-chip>
         Current round: {{ reservationRoundsService.currentRound()?.name || 'none' }}

--- a/hosting/src/app/app.component.ts
+++ b/hosting/src/app/app.component.ts
@@ -1,6 +1,6 @@
-import {Component, inject, OnDestroy, signal, Signal, WritableSignal} from '@angular/core';
+import {Component, inject, model, OnDestroy, signal, Signal, WritableSignal} from '@angular/core';
 import {RouterOutlet} from '@angular/router';
-import {AsyncPipe, KeyValuePipe} from '@angular/common';
+import {AsyncPipe, KeyValuePipe, NgForOf} from '@angular/common';
 import {AuthComponent, authState} from './auth/auth.component';
 import {Auth, User} from '@angular/fire/auth';
 import {catchError, combineLatest, map, Observable} from 'rxjs';
@@ -24,6 +24,9 @@ import {RoundConfigComponent} from './reservations/round-config.component';
 import {BookerPickerComponent} from './utility/booker-picker.component';
 import {toObservable} from '@angular/core/rxjs-interop';
 import {MatChip, MatChipSet} from '@angular/material/chips';
+import {MatFormField, MatOption, MatSelect} from '@angular/material/select';
+import {FormsModule} from '@angular/forms';
+import {MatLabel} from '@angular/material/form-field';
 
 
 @Component({
@@ -40,6 +43,12 @@ import {MatChip, MatChipSet} from '@angular/material/chips';
     MatChip,
     KeyValuePipe,
     MatChipSet,
+    MatSelect,
+    MatOption,
+    NgForOf,
+    MatFormField,
+    FormsModule,
+    MatLabel,
   ],
   templateUrl: './app.component.html',
   styleUrl: './app.component.css'
@@ -72,6 +81,8 @@ export class AppComponent implements OnDestroy {
   currentUserSubscription;
   bookersSubscription;
 
+  currentYear = model(2025);
+
   constructor(dataService: DataService, reservationRoundsService: ReservationRoundsService) {
     this.dataService = dataService;
     this.bookers = dataService.bookers;
@@ -82,6 +93,10 @@ export class AppComponent implements OnDestroy {
     this.unitPricing$ = dataService.unitPricing$;
     this.units$ = dataService.units$;
     this.weeks$ = dataService.weeks$;
+
+    this.currentYear.subscribe(year => {
+      this.dataService.activeYear.next(year);
+    })
 
     this.bookersSubscription = combineLatest([toObservable(dataService.bookers), this.user$, toObservable(this.bookerIdOverride)]).subscribe(
       ([bookers, user, bookerIdOverride]) => {

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -124,13 +124,6 @@ export class WeekTableComponent {
     const bookers = this._bookers();
     const unitPricing = this._unitPricing;
 
-    // Don't render table rows until all data is available.
-    // Exception: allow no current booker if admin.
-    if (!weeks.length || !(currentBooker || this.isAdmin()) || !units.length || !permissions || !Object.keys(pricingTiers).length || !reservations.length || !bookers.length || !Object.keys(unitPricing).length) {
-      this.tableRows$ = of([]);
-      return;
-    }
-
     this.displayedColumns = ['week', ...units.map(unit => unit.name)];
     this.tableRows$ = of(
       weeks.map(week => {
@@ -155,7 +148,7 @@ export class WeekTableComponent {
         });
 
         const reservationsByUnit = weekReservations.reduce((acc: { [key: string]: WeekReservation[] }, reservation) => {
-          const key = reservation.unit.id;
+          const key = reservation.unit?.id;
           if (!acc[key]) {
             acc[key] = [];
           }


### PR DESCRIPTION
Fixes #42
Fixes #47 

To fix the bug in #42 , I ended up implementing #47 so that I could switch to a year without data.

The main change is that we can't simply reassign the observables, because consumers would still be connected to the old ones. So, we need to change those to behavior subjects: the object stays the same but new values come in.

Another tricky part is the rounds config is expected to be an object with useful field values (vs returning an empty array of round configs). It would be ideal to clean that up to work like weeks, we just fetch out the field we actually need. For now, just return a dummy object.

<img width="1370" alt="Screenshot 2025-01-01 at 4 16 18 PM" src="https://github.com/user-attachments/assets/e9af7913-2b33-4aa9-8e84-57e1e6ca444a" />