### PR TITLE
Unit notes

### DIFF
--- a/hosting/package.json
+++ b/hosting/package.json
@@ -24,6 +24,7 @@
     "@angular/router": "^18.2.0",
     "js-cookie": "^3.0.5",
     "luxon": "^3.5.0",
+    "marked": "^15.0.6",
     "rxjs": "~7.8.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.14.10"

--- a/hosting/src/app/data-service.ts
+++ b/hosting/src/app/data-service.ts
@@ -197,9 +197,9 @@ export class DataService {
     const bookableUnitsCollection = collection(firestore, 'units').withConverter<BookableUnit>({
       // We need this to add in the id field.
       fromFirestore: snapshot => {
-        const {name, floorPlanFilename} = snapshot.data();
+        const {name, floorPlanFilename, notesMarkdown} = snapshot.data();
         const {id} = snapshot;
-        return {id, name, floorPlanFilename: floorPlanFilename};
+        return {id, name, floorPlanFilename, notesMarkdown};
       },
       toFirestore: (it: any) => it,
     });

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -5,6 +5,7 @@ export interface BookableUnit {
   id: string;
   name: string;
   floorPlanFilename: string;
+  notesMarkdown: string;
 }
 
 export interface Booker {

--- a/hosting/src/app/units/edit-unit-dialog.component.html
+++ b/hosting/src/app/units/edit-unit-dialog.component.html
@@ -29,6 +29,15 @@
       </button>
     </div>
   </div>
+  <div>
+    <mat-form-field style="width: 35vw">
+      <mat-label>Notes</mat-label>
+      <textarea matInput [(ngModel)]="notesMarkdown"></textarea>
+      <mat-hint>
+        See <a href="https://www.markdownguide.org/cheat-sheet/" target="_blank">Markdown Syntax</a>
+      </mat-hint>
+    </mat-form-field>
+  </div>
 </mat-dialog-content>
 <mat-dialog-actions>
   @if (data.existingUnitId) {

--- a/hosting/src/app/units/edit-unit-dialog.component.ts
+++ b/hosting/src/app/units/edit-unit-dialog.component.ts
@@ -21,6 +21,7 @@ export interface EditUnitDialogData {
   unitPricing: UnitPricing[];
   unitName: string;
   floorPlanFilename: string;
+  notesMarkdown: string;
   existingUnitId?: string;
 }
 
@@ -50,6 +51,7 @@ export class EditUnitDialog {
 
   unitName = model('')
   floorPlanFilename = model('')
+  notesMarkdown = model('');
 
   readonly existingUnitId: string | undefined;
   readonly unitPricing: UnitPricing[];
@@ -62,12 +64,17 @@ export class EditUnitDialog {
   constructor(@Inject(MAT_DIALOG_DATA) public data: EditUnitDialogData) {
     this.unitPricing = data.unitPricing;
     this.unitName.set(data.unitName);
+    this.notesMarkdown.set(data.notesMarkdown);
     this.floorPlanFilename.set(data.floorPlanFilename || "");
     this.existingUnitId = data.existingUnitId;
   }
 
   @HostListener('window:keyup.Enter', ['$event'])
   onKeyPress(_event: KeyboardEvent): void {
+    // Don't close the dialog on enter if we're typing in the text area
+    if (document.activeElement instanceof HTMLTextAreaElement) {
+      return
+    }
     if (this.isValid()) {
       this.onSubmit();
     }
@@ -82,6 +89,7 @@ export class EditUnitDialog {
       id: this.existingUnitId || '',
       name: this.unitName(),
       floorPlanFilename: this.floorPlanFilename(),
+      notesMarkdown: this.notesMarkdown(),
     });
   }
 

--- a/hosting/src/app/units/notes-dialog.component.html
+++ b/hosting/src/app/units/notes-dialog.component.html
@@ -2,9 +2,7 @@
   {{ unitName }}
 </h2>
 <mat-dialog-content>
-  <div>
-    {{ notesMarkdown }}
-  </div>
+  <div [innerHTML]="renderedMarkdown"></div>
 </mat-dialog-content>
 <mat-dialog-actions>
   <button mat-button class="primary-button" [mat-dialog-close]="null">Close</button>

--- a/hosting/src/app/units/notes-dialog.component.html
+++ b/hosting/src/app/units/notes-dialog.component.html
@@ -1,0 +1,11 @@
+<h2 mat-dialog-title>
+  {{ unitName }}
+</h2>
+<mat-dialog-content>
+  <div>
+    {{ notesMarkdown }}
+  </div>
+</mat-dialog-content>
+<mat-dialog-actions>
+  <button mat-button class="primary-button" [mat-dialog-close]="null">Close</button>
+</mat-dialog-actions>

--- a/hosting/src/app/units/notes-dialog.component.ts
+++ b/hosting/src/app/units/notes-dialog.component.ts
@@ -1,0 +1,50 @@
+import {ChangeDetectionStrategy, Component, HostListener, Inject, inject,} from '@angular/core';
+import {MatButton} from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import {FormsModule} from '@angular/forms';
+import {MatInputModule} from '@angular/material/input';
+
+export interface NotesDialogData {
+  notesMarkdown: string;
+  unitName: string;
+}
+
+@Component({
+  selector: 'notes-dialog',
+  templateUrl: 'notes-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton,
+    MatDialogTitle,
+    FormsModule,
+    MatInputModule,
+
+  ]
+})
+export class NotesDialog {
+  readonly dialogRef = inject(MatDialogRef<NotesDialog>);
+
+  unitName: string;
+  notesMarkdown: string;
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: NotesDialogData) {
+    this.unitName = data.unitName;
+    this.notesMarkdown = data.notesMarkdown;
+  }
+
+  @HostListener('window:keyup.Enter', ['$event'])
+  onKeyPress(_event: KeyboardEvent): void {
+    this.dialogRef.close()
+  }
+}

--- a/hosting/src/app/units/notes-dialog.component.ts
+++ b/hosting/src/app/units/notes-dialog.component.ts
@@ -1,4 +1,4 @@
-import {ChangeDetectionStrategy, Component, HostListener, Inject, inject,} from '@angular/core';
+import {ChangeDetectionStrategy, Component, HostListener, Inject, inject, SecurityContext,} from '@angular/core';
 import {MatButton} from '@angular/material/button';
 import {
   MAT_DIALOG_DATA,
@@ -10,6 +10,8 @@ import {
 } from '@angular/material/dialog';
 import {FormsModule} from '@angular/forms';
 import {MatInputModule} from '@angular/material/input';
+import {DomSanitizer} from '@angular/platform-browser';
+import {marked} from 'marked';
 
 export interface NotesDialogData {
   notesMarkdown: string;
@@ -33,14 +35,19 @@ export interface NotesDialogData {
   ]
 })
 export class NotesDialog {
+  readonly domSanitizer = inject(DomSanitizer);
   readonly dialogRef = inject(MatDialogRef<NotesDialog>);
 
   unitName: string;
   notesMarkdown: string;
+  renderedMarkdown: string;
 
   constructor(@Inject(MAT_DIALOG_DATA) public data: NotesDialogData) {
     this.unitName = data.unitName;
     this.notesMarkdown = data.notesMarkdown;
+
+    const parsedMarkdown = marked.parse(data.notesMarkdown);
+    this.renderedMarkdown = this.domSanitizer.sanitize(SecurityContext.HTML, parsedMarkdown) || "";
   }
 
   @HostListener('window:keyup.Enter', ['$event'])

--- a/hosting/src/app/week-table.component.css
+++ b/hosting/src/app/week-table.component.css
@@ -7,3 +7,22 @@
 .add-button {
   text-align: center;
 }
+
+div.edit-unit {
+  display: inline-block;
+  vertical-align: top;
+}
+
+div.unit-header {
+  display: inline-block;
+}
+
+table {
+  margin-top: 1em;
+}
+
+th.unit-header {
+  padding-top: 0.75em;
+  padding-bottom: 0.75em;
+  vertical-align: top;
+}

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -13,18 +13,29 @@
   <!-- Unit Columns -->
   @for (unit of units; track unit.id) {
     <ng-container [matColumnDef]="unit.name">
-      <th mat-header-cell *matHeaderCellDef>
+      <th class="unit-header" mat-header-cell *matHeaderCellDef>
         @if (canEditUnit()) {
-          <div class="mat-button-small" style="float: left">
+          <div class="mat-button-small" class="edit-unit">
             <button mat-icon-button aria-label="Edit unit" (click)="editUnit(unit)">
               <mat-icon>edit</mat-icon>
             </button>
           </div>
         }
-        <div>{{ unit.name }}</div>
-        @if (unit.floorPlanFilename) {
-          <div><a href="{{downloadUrls[unit.id] | async}}">Floor plan</a></div>
-        }
+        <div class="unit-header">
+          <div>{{ unit.name }}</div>
+          @if (unit.floorPlanFilename) {
+            <div>
+              <mat-icon class="vertical-middle">gite</mat-icon>
+              <a mat-button href="{{downloadUrls[unit.id] | async}}" target="_blank">Floor plan</a>
+            </div>
+          }
+          @if (unit.notesMarkdown) {
+            <div>
+              <mat-icon class="vertical-middle">description</mat-icon>
+              <button mat-button class="vertical-middle" (click)="openNotesDialog(unit)">Notes</button>
+            </div>
+          }
+        </div>
       </th>
       <td mat-cell *matCellDef="let weekRow">
         @let unitReservations = weekRow.reservations[unit.id] || [];

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -30,7 +30,7 @@ import {
   UnitPricingMap
 } from './types';
 import {DataService} from './data-service';
-import {MatIconButton} from '@angular/material/button';
+import {MatAnchor, MatButton, MatIconButton} from '@angular/material/button';
 import {MatIcon} from '@angular/material/icon';
 import {ReserveDialog, ReserveDialogData} from './reservations/reserve-dialog.component';
 import {MatDialog} from '@angular/material/dialog';
@@ -44,6 +44,7 @@ import {MatAccordion, MatExpansionPanel, MatExpansionPanelHeader} from '@angular
 import {MatList, MatListItem, MatListItemLine, MatListItemTitle} from '@angular/material/list';
 import {getDownloadURL, ref, Storage} from '@angular/fire/storage';
 import {EditUnitDialog} from './units/edit-unit-dialog.component';
+import {NotesDialog} from './units/notes-dialog.component';
 
 
 interface WeekRow {
@@ -94,6 +95,8 @@ interface WeekReservation {
     MatListItemLine,
     MatListItemTitle,
     AsyncPipe,
+    MatButton,
+    MatAnchor,
   ],
   templateUrl: './week-table.component.html',
   styleUrl: './week-table.component.css'
@@ -123,14 +126,10 @@ export class WeekTableComponent {
   displayedColumns: string[] = [];
 
   buildTableRows() {
-    const currentBooker = this._currentBooker();
     const weeks = this._weeks;
     const units = this._units;
-    const permissions = this._permissions;
     const pricingTiers = this._pricingTiers;
     const reservations = this._reservations;
-    const bookers = this._bookers();
-    const unitPricing = this._unitPricing;
 
     this.displayedColumns = ['week', ...units.map(unit => unit.name)];
     this.tableRows$ = of(
@@ -327,10 +326,12 @@ export class WeekTableComponent {
 
   editUnit(unit: BookableUnit) {
     const dialogRef = this.dialog.open(EditUnitDialog, {
+      minWidth: '40vw',
       data: {
         unitName: unit.name,
         existingUnitId: unit.id,
         floorPlanFilename: unit.floorPlanFilename,
+        notesMarkdown: unit.notesMarkdown || "",
         unitPricing: this._unitPricing[unit.id] || [],
       },
       ...ANIMATION_SETTINGS,
@@ -344,9 +345,9 @@ export class WeekTableComponent {
       });
     });
 
-      dialogRef.componentInstance.deleteUnit.subscribe(() => {
-        console.log('Delete unit', unit);
-      });
+    dialogRef.componentInstance.deleteUnit.subscribe(() => {
+      console.log('Delete unit', unit);
+    });
   }
 
   editReservation(reservation: WeekReservation, week: WeekRow) {
@@ -429,6 +430,17 @@ export class WeekTableComponent {
       console.log('Reservation deleted');
     }).catch((error) => {
       this.dialog.open(ErrorDialog, {data: `Couldn't delete reservation: ${error.message}`, ...ANIMATION_SETTINGS});
+    });
+  }
+
+  openNotesDialog(unit: BookableUnit) {
+    this.dialog.open(NotesDialog, {
+      minWidth: '40vw',
+      data: {
+        unitName: unit.name,
+        notesMarkdown: unit.notesMarkdown || "",
+      },
+      ...ANIMATION_SETTINGS,
     });
   }
 

--- a/hosting/src/styles.scss
+++ b/hosting/src/styles.scss
@@ -43,6 +43,10 @@ $reservations-app-theme: mat.define-theme((
   @include mat.button-color($reservations-app-theme, $color-variant: secondary);
 }
 
+.tertiary-button {
+  @include mat.button-color($reservations-app-theme, $color-variant: tertiary);
+}
+
 .error-button {
   @include mat.button-color($reservations-app-theme, $color-variant: error);
 }
@@ -65,6 +69,10 @@ body {
 .mat-button-small {
   @include mat.button-density(-10);
   @include mat.icon-button-density(-10);
+}
+
+.vertical-middle {
+  vertical-align: middle;
 }
 
 main {


### PR DESCRIPTION
Fixes #50 

Add notes to units, using Markdown formatting.

<img width="1071" alt="Screenshot 2025-01-11 at 9 48 59 PM" src="https://github.com/user-attachments/assets/18b4a598-aabc-42ea-9f1f-bb49e9803f9c" />

Rendered markdown:

<img width="601" alt="Screenshot 2025-01-11 at 9 49 12 PM" src="https://github.com/user-attachments/assets/e889ca0f-a1ea-48ec-bb28-fd35a64f3c83" />

Edit dialog w/ text area + cheat sheet link:

<img width="552" alt="Screenshot 2025-01-11 at 9 49 30 PM" src="https://github.com/user-attachments/assets/15109e9e-c4f8-4920-8dcd-de1cb2432ebc" />