### PR TITLE
Configure prices

### DIFF
--- a/hosting/src/app/admin/admin.component.html
+++ b/hosting/src/app/admin/admin.component.html
@@ -14,6 +14,7 @@
     <p>
       <mat-button-toggle-group name="adminSection" aria-label="Admin sections" [(ngModel)]="activeChild">
         <mat-button-toggle value="floor-plans" routerLink="floor-plans">Floor plans</mat-button-toggle>
+        <mat-button-toggle value="unit-pricing" routerLink="unit-pricing">Unit pricing</mat-button-toggle>
       </mat-button-toggle-group>
     </p>
 

--- a/hosting/src/app/admin/floor-plans.component.ts
+++ b/hosting/src/app/admin/floor-plans.component.ts
@@ -92,6 +92,4 @@ export class FloorPlanComponent {
       this.dialog.open(ErrorDialog, {data: `Couldn't delete floor plan: ${error.message}`, ...ANIMATION_SETTINGS});
     });
   }
-
-  protected readonly alert = alert;
 }

--- a/hosting/src/app/admin/unit-pricing.component.html
+++ b/hosting/src/app/admin/unit-pricing.component.html
@@ -1,0 +1,17 @@
+<mat-form-field>
+  <mat-select [(ngModel)]="selectedUnitId" placeholder="Select a unit…">
+    <mat-option *ngFor="let unit of units()" [value]="unit.id">{{ unit.name }}</mat-option>
+  </mat-select>
+</mat-form-field>
+
+@if (unit()) {
+  <mat-card>
+    <mat-card-header>
+      <h1>Unit pricing for {{ unit()?.name }} in {{ year() }}</h1>
+    </mat-card-header>
+    <mat-card-content>
+      <mat-list>
+      </mat-list>
+    </mat-card-content>
+  </mat-card>
+}

--- a/hosting/src/app/admin/unit-pricing.component.html
+++ b/hosting/src/app/admin/unit-pricing.component.html
@@ -10,8 +10,30 @@
       <h1>Unit pricing for {{ unit()?.name }} in {{ year() }}</h1>
     </mat-card-header>
     <mat-card-content>
-      <mat-list>
-      </mat-list>
+      <form [formGroup]="form()">
+        @for (tierId of tierIds(); track tierId) {
+          @let tier = tiers()[tierId];
+
+          <h4>{{ tier.name }}</h4>
+          <div>
+            <mat-form-field>
+              <mat-label>Daily price</mat-label>
+              <input matInput type="number" required [formControlName]="tierId + '_dailyPrice'"
+                     [id]="tierId + '_dailyPrice'">
+            </mat-form-field>
+          </div>
+          <div>
+            <mat-form-field>
+              <mat-label>Weekly price</mat-label>
+              <input matInput type="number" required [formControlName]="tierId + '_weeklyPrice'"
+                     [id]="tierId + '_weeklyPrice'">
+            </mat-form-field>
+          </div>
+        }
+      </form>
     </mat-card-content>
+    <mat-card-actions>
+      <button mat-button class="primary-button" (click)="onSubmit()" [disabled]="!form().valid">Update</button>
+    </mat-card-actions>
   </mat-card>
 }

--- a/hosting/src/app/admin/unit-pricing.component.ts
+++ b/hosting/src/app/admin/unit-pricing.component.ts
@@ -1,0 +1,70 @@
+import {Component, computed, inject, OnDestroy, OnInit, signal, Signal} from '@angular/core';
+import {DataService} from '../data-service';
+import {MatList} from '@angular/material/list';
+import {MatCard, MatCardContent, MatCardHeader} from '@angular/material/card';
+import {map, Subscription} from 'rxjs';
+import {Storage} from '@angular/fire/storage';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatDialog} from "@angular/material/dialog";
+import {UnitPricing} from '../types';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {ActivatedRoute} from '@angular/router';
+import {MatFormField} from '@angular/material/form-field';
+import {MatOption, MatSelect} from '@angular/material/select';
+import {NgForOf} from '@angular/common';
+import {FormsModule} from '@angular/forms';
+
+@Component({
+  selector: 'unit-pricing',
+  standalone: true,
+  imports: [
+    MatList,
+    MatCard,
+    MatCardHeader,
+    MatCardContent,
+    MatFormField,
+    MatSelect,
+    MatOption,
+    NgForOf,
+    FormsModule
+  ],
+  templateUrl: './unit-pricing.component.html',
+})
+export class UnitPricingComponent implements OnInit, OnDestroy {
+  private readonly dataService = inject(DataService);
+  private readonly dialog = inject(MatDialog);
+  private readonly snackBar = inject(MatSnackBar);
+  private readonly storage = inject(Storage);
+
+  year: Signal<Number>
+  selectedUnitId = signal('');
+  units = this.dataService.units;
+  unitPricing: UnitPricing[];
+
+  unit = computed(() => {
+    return this.units().find(unit => unit.id === this.selectedUnitId())
+  });
+
+  private paramSubscription?: Subscription;
+
+  ngOnInit() {
+
+    this.paramSubscription = this.route.paramMap.pipe(
+      map(params => {
+        return params.get('unitId');
+      })
+    ).subscribe(unitId => {
+      this.selectedUnitId.set(unitId || "");
+    });
+  }
+
+  ngOnDestroy() {
+    this.paramSubscription?.unsubscribe();
+  }
+
+  constructor(private route: ActivatedRoute) {
+    this.unitPricing = [];
+    this.year = toSignal(this.dataService.activeYear, {initialValue: 0});
+  }
+
+}

--- a/hosting/src/app/app.routes.ts
+++ b/hosting/src/app/app.routes.ts
@@ -2,6 +2,7 @@ import {Routes} from '@angular/router';
 import {ReservationsComponent} from './reservations.component';
 import {AdminComponent} from './admin/admin.component';
 import {FloorPlanComponent} from './admin/floor-plans.component';
+import {UnitPricingComponent} from './admin/unit-pricing.component';
 
 export const routes: Routes = [
   {path: 'reservations', component: ReservationsComponent},
@@ -12,7 +13,15 @@ export const routes: Routes = [
       {
         path: 'floor-plans',
         component: FloorPlanComponent,
-      }
+      },
+      {
+        path: 'unit-pricing',
+        component: UnitPricingComponent,
+      },
+      {
+        path: 'unit-pricing/:unitId',
+        component: UnitPricingComponent,
+      },
     ]
   },
   {path: '', redirectTo: '/reservations', pathMatch: 'full'},

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -81,6 +81,7 @@ export interface ReservationRoundsConfig {
 }
 
 export interface UnitPricing {
+  id: string;
   year: number;
   tierId: string;
   unitId: string;

--- a/hosting/src/app/units/edit-unit-dialog.component.html
+++ b/hosting/src/app/units/edit-unit-dialog.component.html
@@ -23,12 +23,19 @@
         }
       </mat-select>
     </mat-form-field>
+  </div>
+  @if (existingUnitId) {
     <div>
       <button mat-button class="secondary-button" [mat-dialog-close]="null" routerLink="/admin/floor-plans">
         Manage floor plans
       </button>
+      <button mat-button class="secondary-button" [mat-dialog-close]="null"
+              [routerLink]="['/admin', 'unit-pricing', existingUnitId]">
+        Manage prices
+      </button>
+      <div class="mat-mdc-form-field-subscript-wrapper mat-mdc-form-field-bottom-align"></div>
     </div>
-  </div>
+  }
   <div>
     <mat-form-field style="width: 35vw">
       <mat-label>Notes</mat-label>


### PR DESCRIPTION
Fixes #70 

Prices can be edited from the unit edit panel:

<img width="660" alt="Screenshot 2025-01-12 at 12 29 25 AM" src="https://github.com/user-attachments/assets/1512f6bf-a900-498a-9975-8c1253072777" />

Which brings us to a new section of the admin panel:

<img width="1253" alt="Screenshot 2025-01-12 at 12 29 45 AM" src="https://github.com/user-attachments/assets/36651f38-155e-4755-acd4-63b0c6d0f770" />

When done, click 'update':

<img width="329" alt="Screenshot 2025-01-12 at 12 29 59 AM" src="https://github.com/user-attachments/assets/807f631d-4d4c-4cde-8445-c510780f27ca" />

and voilà, prices are updated