### PR TITLE
Manage reservation rounds

### DIFF
--- a/hosting/src/app/admin/admin.component.html
+++ b/hosting/src/app/admin/admin.component.html
@@ -13,8 +13,15 @@
     }
     <p>
       <mat-button-toggle-group name="adminSection" aria-label="Admin sections" [(ngModel)]="activeChild">
-        <mat-button-toggle value="floor-plans" routerLink="floor-plans">Floor plans</mat-button-toggle>
-        <mat-button-toggle value="unit-pricing" routerLink="unit-pricing">Unit pricing</mat-button-toggle>
+        <mat-button-toggle value="floor-plans" routerLink="floor-plans">
+          Floor plans
+        </mat-button-toggle>
+        <mat-button-toggle value="reservation-rounds" routerLink="reservation-rounds">
+          Reservation rounds
+        </mat-button-toggle>
+        <mat-button-toggle value="unit-pricing" routerLink="unit-pricing">
+          Unit pricing
+        </mat-button-toggle>
       </mat-button-toggle-group>
     </p>
 

--- a/hosting/src/app/admin/edit-round-dialog.component.html
+++ b/hosting/src/app/admin/edit-round-dialog.component.html
@@ -1,0 +1,95 @@
+<h2 mat-dialog-title>
+  @if (data.existingPosition) {
+    Modify round
+  } @else {
+    Create round
+  }
+</h2>
+<mat-dialog-content>
+  <div>
+    <mat-form-field>
+      <mat-label>Name</mat-label>
+      <input matInput [(ngModel)]="name" required/>
+      <mat-error>Name is required</mat-error>
+    </mat-form-field>
+  </div>
+  <p>Allow daily reservations:</p>
+  <div>
+    <mat-button-toggle-group
+      [(ngModel)]="allowDailyReservations"
+      aria-label="Allow daily reservations"
+    >
+      <mat-button-toggle [value]="false">Weekly only</mat-button-toggle>
+      <mat-button-toggle [value]="true">Daily possible</mat-button-toggle>
+    </mat-button-toggle-group>
+    <div>&nbsp;</div>
+  </div>
+  <p>Round duration:</p>
+  <div>
+    <mat-button-toggle-group
+      [(ngModel)]="isRoundRobin"
+      aria-label="Is round robin"
+    >
+      <mat-button-toggle [value]="true">Priority rounds</mat-button-toggle>
+      <mat-button-toggle [value]="false">Duration</mat-button-toggle>
+    </mat-button-toggle-group>
+    <div>&nbsp;</div>
+  </div>
+  @if (isRoundRobin()) {
+    @let numBookers = subRoundBookerIds()?.length || 0;
+    <div>
+      <p>Priority round order:</p>
+      <mat-list>
+        @for (bookerId of subRoundBookerIds(); track bookerId) {
+          <mat-list-item>
+            <button mat-icon-button (click)="moveUp($index)" [disabled]="$index === 0">
+              <mat-icon>arrow_drop_up</mat-icon>
+            </button>
+            <button mat-icon-button (click)="moveDown($index)" [disabled]="$index === numBookers - 1">
+              <mat-icon>arrow_drop_down</mat-icon>
+            </button>
+            <span>{{ bookerName(bookerId) }}</span>
+          </mat-list-item>
+        }
+      </mat-list>
+    </div>
+  } @else {
+    <div>
+      <mat-form-field>
+        <mat-label>Duration (weeks)</mat-label>
+        <input matInput type="number" [(ngModel)]="durationWeeks" min="1"/>
+        <mat-error>Duration must be at least one</mat-error>
+      </mat-form-field>
+    </div>
+  }
+  <div>
+    <mat-form-field>
+      <mat-label>Booking limit (weeks)</mat-label>
+      <input matInput type="number" [(ngModel)]="bookingLimitWeeks" min="0"/>
+      <mat-hint>Zero or blank for none</mat-hint>
+    </mat-form-field>
+  </div>
+  <!--  <div>-->
+  <!--    <mat-form-field>-->
+  <!--      <mat-label>Booked by</mat-label>-->
+  <!--      <mat-select [(ngModel)]="bookerId" required>-->
+  <!--        @for (booker of bookers; track booker.id) {-->
+  <!--          <mat-option [value]="booker.id">{{ booker.name }}</mat-option>-->
+  <!--        }-->
+  <!--      </mat-select>-->
+  <!--    </mat-form-field>-->
+  <!--  </div>-->
+</mat-dialog-content>
+<mat-dialog-actions>
+  @if (data.existingPosition) {
+    <button mat-button class="error-button" (click)="onDelete()">Delete</button>
+  }
+  <button mat-button class="secondary-button" [mat-dialog-close]="null">Cancel</button>
+  <button mat-button class="primary-button" (click)="onSubmit()" [disabled]="!isValid()">
+    @if (data.existingPosition) {
+      Modify
+    } @else {
+      Save
+    }
+  </button>
+</mat-dialog-actions>

--- a/hosting/src/app/admin/edit-round-dialog.component.html
+++ b/hosting/src/app/admin/edit-round-dialog.component.html
@@ -69,19 +69,9 @@
       <mat-hint>Zero or blank for none</mat-hint>
     </mat-form-field>
   </div>
-  <!--  <div>-->
-  <!--    <mat-form-field>-->
-  <!--      <mat-label>Booked by</mat-label>-->
-  <!--      <mat-select [(ngModel)]="bookerId" required>-->
-  <!--        @for (booker of bookers; track booker.id) {-->
-  <!--          <mat-option [value]="booker.id">{{ booker.name }}</mat-option>-->
-  <!--        }-->
-  <!--      </mat-select>-->
-  <!--    </mat-form-field>-->
-  <!--  </div>-->
 </mat-dialog-content>
 <mat-dialog-actions>
-  @if (data.existingPosition) {
+  @if (data.existingPosition !== undefined) {
     <button mat-button class="error-button" (click)="onDelete()">Delete</button>
   }
   <button mat-button class="secondary-button" [mat-dialog-close]="null">Cancel</button>

--- a/hosting/src/app/admin/edit-round-dialog.component.ts
+++ b/hosting/src/app/admin/edit-round-dialog.component.ts
@@ -118,13 +118,21 @@ export class EditRoundDialog {
   }
 
   onSubmit(): void {
-    this.round.emit({
+    const round = {
       name: this.name(),
-      durationWeeks: this.durationWeeks(),
-      subRoundBookerIds: this.subRoundBookerIds(),
-      bookedWeeksLimit: this.bookingLimitWeeks(),
       allowDailyReservations: this.allowDailyReservations(),
-    });
+      bookedWeeksLimit: this.bookingLimitWeeks(),
+    } as ReservationRoundDefinition;
+
+    // Don't add undefined fields
+    if (this.subRoundBookerIds()) {
+      round.subRoundBookerIds = this.subRoundBookerIds();
+    }
+    if (this.durationWeeks()) {
+      round.durationWeeks = this.durationWeeks();
+    }
+
+    this.round.emit(round);
   }
 
   onDelete(): void {

--- a/hosting/src/app/admin/edit-round-dialog.component.ts
+++ b/hosting/src/app/admin/edit-round-dialog.component.ts
@@ -1,0 +1,151 @@
+import {
+  ChangeDetectionStrategy,
+  Component,
+  HostListener,
+  Inject,
+  inject,
+  model,
+  ModelSignal,
+  output,
+} from '@angular/core';
+import {MatButton, MatIconButton} from '@angular/material/button';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import {FormsModule} from '@angular/forms';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput, MatInputModule} from '@angular/material/input';
+import {Booker, ReservationRoundDefinition} from '../types';
+import {MatDatepickerModule} from '@angular/material/datepicker';
+import {MatLuxonDateModule} from '@angular/material-luxon-adapter';
+import {MatButtonToggle, MatButtonToggleGroup} from '@angular/material/button-toggle';
+import {MatList, MatListItem} from '@angular/material/list';
+import {MatIcon} from '@angular/material/icon';
+
+export interface ReserveDialogData {
+  existingPosition?: number;
+  bookers: Booker[];
+  name: string;
+  durationWeeks?: number;
+  subRoundBookerIds?: string[];
+  bookedWeeksLimit?: number;
+  allowDailyReservations: boolean;
+}
+
+@Component({
+  selector: 'edit-round-dialog',
+  templateUrl: 'edit-round-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatDialogContent,
+    MatFormField,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton,
+    MatInput,
+    MatLabel,
+    MatDialogTitle,
+    FormsModule,
+    MatDatepickerModule,
+    MatLuxonDateModule,
+    MatInputModule,
+    MatButtonToggleGroup,
+    MatButtonToggle,
+    MatListItem,
+    MatList,
+    MatIconButton,
+    MatIcon,
+
+  ]
+})
+export class EditRoundDialog {
+  readonly dialogRef = inject(MatDialogRef<EditRoundDialog>);
+
+  readonly bookers: Booker[];
+  readonly existingPosition: number | undefined;
+  readonly name = model('');
+  readonly durationWeeks: ModelSignal<number | undefined> = model(undefined as number | undefined);
+  readonly subRoundBookerIds: ModelSignal<string[] | undefined> = model(undefined as string[] | undefined);
+  readonly bookingLimitWeeks: ModelSignal<number | undefined> = model(undefined as number | undefined);
+  readonly allowDailyReservations = model(false);
+
+  readonly isRoundRobin = model(false);
+
+  round = output<ReservationRoundDefinition>();
+  deleteRound = output<void>();
+
+  constructor(@Inject(MAT_DIALOG_DATA) public data: ReserveDialogData) {
+    this.bookers = data.bookers;
+    this.existingPosition = data.existingPosition;
+    this.name.set(data.name);
+    this.durationWeeks.set(data.durationWeeks);
+    this.subRoundBookerIds.set(data.subRoundBookerIds);
+    this.bookingLimitWeeks.set(data.bookedWeeksLimit || 0);
+    this.allowDailyReservations.set(data.allowDailyReservations);
+
+    this.isRoundRobin.set(!!this.subRoundBookerIds() && this.subRoundBookerIds()!.length > 0);
+
+    this.isRoundRobin.subscribe((isRoundRobin) => {
+      if (isRoundRobin) {
+        this.subRoundBookerIds.set(this.bookers.map(b => b.id));
+        this.durationWeeks.set(undefined);
+      } else {
+        this.subRoundBookerIds.set(undefined);
+        this.durationWeeks.set(0);
+      }
+    });
+  }
+
+  @HostListener('window:keyup.Enter', ['$event'])
+  onKeyPress(_event: KeyboardEvent): void {
+    if (this.isValid()) {
+      this.onSubmit();
+    }
+  }
+
+  isValid(): boolean {
+    return this.name().length > 0 &&
+      (!!this.subRoundBookerIds() || !!this.durationWeeks()) &&
+      !(!!this.subRoundBookerIds() && !!this.durationWeeks()) &&
+      (!this.subRoundBookerIds() || this.subRoundBookerIds()!.length > 0) &&
+      (!this.durationWeeks() || this.durationWeeks()! > 0);
+  }
+
+  onSubmit(): void {
+    this.round.emit({
+      name: this.name(),
+      durationWeeks: this.durationWeeks(),
+      subRoundBookerIds: this.subRoundBookerIds(),
+      bookedWeeksLimit: this.bookingLimitWeeks(),
+      allowDailyReservations: this.allowDailyReservations(),
+    });
+  }
+
+  onDelete(): void {
+    if (confirm(`Really delete round ${this.name()}? This cannot be undone`)) {
+      this.deleteRound.emit();
+    }
+  }
+
+  moveUp(index: number) {
+    const newBookerIds = [...this.subRoundBookerIds()!];
+    newBookerIds.splice(index - 1, 0, newBookerIds.splice(index, 1)[0]);
+    this.subRoundBookerIds.set(newBookerIds);
+  }
+
+  moveDown(index: number) {
+    const newBookerIds = [...this.subRoundBookerIds()!];
+    newBookerIds.splice(index + 1, 0, newBookerIds.splice(index, 1)[0]);
+    this.subRoundBookerIds.set(newBookerIds);
+  }
+
+  bookerName(bookerId: string) {
+    return this.bookers.find(b => b.id === bookerId)?.name || bookerId;
+  }
+}

--- a/hosting/src/app/admin/reservation-rounds.component.html
+++ b/hosting/src/app/admin/reservation-rounds.component.html
@@ -18,7 +18,7 @@
       </mat-form-field>
 
       <ul>
-        @for (roundDef of reservationRoundsDefinitions(); track roundDef) {
+        @for (roundDef of reservationRoundsDefinitions(); track $index) {
           <li>
             Round {{ $index + 1 }}: {{ roundDef.name }}
             <button mat-button class="secondary-button" (click)="editRound($index)">Edit</button>

--- a/hosting/src/app/admin/reservation-rounds.component.html
+++ b/hosting/src/app/admin/reservation-rounds.component.html
@@ -21,7 +21,7 @@
         @for (roundDef of reservationRoundsDefinitions(); track roundDef) {
           <li>
             Round {{ $index + 1 }}: {{ roundDef.name }}
-            <button mat-button class="secondary-button" (click)="$index">Edit</button>
+            <button mat-button class="secondary-button" (click)="editRound($index)">Edit</button>
           </li>
         }
       </ul>

--- a/hosting/src/app/admin/reservation-rounds.component.html
+++ b/hosting/src/app/admin/reservation-rounds.component.html
@@ -24,6 +24,9 @@
             <button mat-button class="secondary-button" (click)="editRound($index)">Edit</button>
           </li>
         }
+        <li>
+          <button mat-button class="secondary-button" (click)="addRound()">Add round</button>
+        </li>
       </ul>
 
       <h2>Preview</h2>

--- a/hosting/src/app/admin/reservation-rounds.component.html
+++ b/hosting/src/app/admin/reservation-rounds.component.html
@@ -1,0 +1,38 @@
+@if (reservationRoundsConfig()) {
+  <mat-card>
+    <mat-card-header>
+      <h1>Reservation rounds for {{ year() }}</h1>
+    </mat-card-header>
+    <mat-card-content>
+      <h2>Configuration</h2>
+      <mat-form-field>
+        <mat-label>Start date</mat-label>
+        <input matInput
+               [min]="yearStart"
+               [max]="yearEnd"
+               [matDatepicker]="startPicker"
+               [(ngModel)]="roundsStartDate"/>
+        <mat-datepicker-toggle matIconSuffix [for]="startPicker"></mat-datepicker-toggle>
+        <mat-datepicker #startPicker></mat-datepicker>
+        <mat-error>Invalid date</mat-error>
+      </mat-form-field>
+
+      <ul>
+        @for (roundDef of reservationRoundsDefinitions(); track roundDef) {
+          <li>
+            Round {{ $index + 1 }}: {{ roundDef.name }}
+            <button mat-button class="secondary-button" (click)="$index">Edit</button>
+          </li>
+        }
+      </ul>
+
+      <h2>Preview</h2>
+      <round-config [rounds$]="rounds()" [bookers]="bookers"/>
+    </mat-card-content>
+    <mat-card-actions>
+      <button mat-button class="primary-button" (click)="onSubmit()" [disabled]="false">Update</button>
+    </mat-card-actions>
+  </mat-card>
+} @else {
+  Loading…
+}

--- a/hosting/src/app/admin/reservation-rounds.component.ts
+++ b/hosting/src/app/admin/reservation-rounds.component.ts
@@ -1,0 +1,99 @@
+import {
+  Component,
+  computed,
+  inject,
+  model,
+  ModelSignal,
+  OnDestroy,
+  OutputRefSubscription,
+  signal,
+  Signal
+} from '@angular/core';
+import {DataService} from '../data-service';
+import {MatCard, MatCardActions, MatCardContent, MatCardHeader} from '@angular/material/card';
+import {of} from 'rxjs';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {MatDialog} from "@angular/material/dialog";
+import {ReservationRound, ReservationRoundsConfig} from '../types';
+import {toSignal} from '@angular/core/rxjs-interop';
+import {ActivatedRoute} from '@angular/router';
+import {MatError, MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {FormsModule, ReactiveFormsModule} from '@angular/forms';
+import {MatInput} from '@angular/material/input';
+import {MatButton} from '@angular/material/button';
+import {ReservationRoundsService} from '../reservations/reservation-rounds-service';
+import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
+import {DateTime} from 'luxon';
+import {RoundConfigComponent} from '../reservations/round-config.component';
+
+@Component({
+  selector: 'reservation-rounds-admin',
+  standalone: true,
+  imports: [
+    MatCard,
+    MatCardHeader,
+    MatCardContent,
+    MatFormField,
+    FormsModule,
+    MatInput,
+    MatLabel,
+    ReactiveFormsModule,
+    MatCardActions,
+    MatButton,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerToggle,
+    MatError,
+    MatSuffix,
+    RoundConfigComponent,
+  ],
+  templateUrl: './reservation-rounds.component.html',
+})
+export class ReservationRoundsComponent implements OnDestroy {
+  private readonly dataService = inject(DataService);
+  private readonly dialog = inject(MatDialog);
+  private readonly reservationRoundsService = inject(ReservationRoundsService);
+  private readonly snackBar = inject(MatSnackBar);
+
+  year: Signal<number>
+  reservationRoundsConfig = signal({} as ReservationRoundsConfig);
+  reservationRoundsDefinitions = computed(() => this.reservationRoundsConfig()?.rounds || []);
+
+  roundsStartDate: ModelSignal<DateTime> = model(DateTime.now());
+
+  rounds = computed(() => {
+    if (!!this.reservationRoundsConfig()) {
+      return of(this.reservationRoundsService.definitionsToRounds(this.reservationRoundsConfig()));
+    } else {
+      return of([] as ReservationRound[]);
+    }
+  })
+
+  // Support data
+  readonly bookers = this.dataService.bookers;
+  readonly yearStart = computed(() => DateTime.fromISO(`${this.year()}-01-01`));
+  readonly yearEnd = computed(() => DateTime.fromISO(`${this.year()}-12-31`));
+
+  private roundsSubscription?: OutputRefSubscription;
+
+  ngOnDestroy() {
+    this.roundsSubscription?.unsubscribe();
+  }
+
+  constructor(private route: ActivatedRoute) {
+    this.year = toSignal(this.dataService.activeYear, {initialValue: 0});
+    this.dataService.reservationRoundsConfig$.subscribe(config => {
+      this.reservationRoundsConfig.set(config);
+      this.roundsStartDate.set(DateTime.fromISO(config.startDate));
+    });
+
+    this.roundsSubscription = this.roundsStartDate.subscribe(date => {
+      const newConfig = {...this.reservationRoundsConfig()}
+      newConfig.startDate = date.toISO()!;
+      this.reservationRoundsConfig.set(newConfig);
+    });
+  }
+
+  onSubmit() {
+  }
+}

--- a/hosting/src/app/admin/reservation-rounds.component.ts
+++ b/hosting/src/app/admin/reservation-rounds.component.ts
@@ -14,7 +14,7 @@ import {MatCard, MatCardActions, MatCardContent, MatCardHeader} from '@angular/m
 import {of} from 'rxjs';
 import {MatSnackBar} from '@angular/material/snack-bar';
 import {MatDialog} from "@angular/material/dialog";
-import {ReservationRound, ReservationRoundsConfig} from '../types';
+import {ReservationRound, ReservationRoundDefinition, ReservationRoundsConfig} from '../types';
 import {toSignal} from '@angular/core/rxjs-interop';
 import {ActivatedRoute} from '@angular/router';
 import {MatError, MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
@@ -25,6 +25,8 @@ import {ReservationRoundsService} from '../reservations/reservation-rounds-servi
 import {MatDatepicker, MatDatepickerInput, MatDatepickerToggle} from '@angular/material/datepicker';
 import {DateTime} from 'luxon';
 import {RoundConfigComponent} from '../reservations/round-config.component';
+import {ANIMATION_SETTINGS} from '../app.config';
+import {EditRoundDialog} from './edit-round-dialog.component';
 
 @Component({
   selector: 'reservation-rounds-admin',
@@ -91,6 +93,35 @@ export class ReservationRoundsComponent implements OnDestroy {
       const newConfig = {...this.reservationRoundsConfig()}
       newConfig.startDate = date.toISO()!;
       this.reservationRoundsConfig.set(newConfig);
+    });
+  }
+
+  editRound(index: number) {
+    const round = this.reservationRoundsDefinitions()[index];
+
+    const dialogRef = this.dialog.open(EditRoundDialog, {
+      minWidth: '40vw',
+      data: {
+        name: round.name,
+        durationWeeks: round.durationWeeks,
+        subRoundBookerIds: round.subRoundBookerIds,
+        bookedWeeksLimit: round.bookedWeeksLimit,
+        allowDailyReservations: round.allowDailyReservations || false,
+        bookers: this.bookers(),
+        existingPosition: index,
+      },
+      ...ANIMATION_SETTINGS,
+    });
+    dialogRef.componentInstance.round.subscribe((round: ReservationRoundDefinition) => {
+      console.log(`New round: ${JSON.stringify(round)}`);
+      const newConfig = {...this.reservationRoundsConfig()};
+      newConfig.rounds[index] = round;
+      this.reservationRoundsConfig.set(newConfig);
+      dialogRef.close();
+    });
+
+    dialogRef.componentInstance.deleteRound.subscribe(() => {
+      console.log('Delete round');
     });
   }
 

--- a/hosting/src/app/admin/reservation-rounds.component.ts
+++ b/hosting/src/app/admin/reservation-rounds.component.ts
@@ -91,7 +91,7 @@ export class ReservationRoundsComponent implements OnDestroy {
 
     this.roundsSubscription = this.roundsStartDate.subscribe(date => {
       const newConfig = {...this.reservationRoundsConfig()}
-      newConfig.startDate = date.toISO()!;
+      newConfig.startDate = date.toISODate()!;
       this.reservationRoundsConfig.set(newConfig);
     });
   }

--- a/hosting/src/app/admin/reservation-rounds.component.ts
+++ b/hosting/src/app/admin/reservation-rounds.component.ts
@@ -96,11 +96,30 @@ export class ReservationRoundsComponent implements OnDestroy {
     });
   }
 
+  addRound() {
+    const dialogRef = this.dialog.open(EditRoundDialog, {
+      data: {
+        name: `Round ${this.reservationRoundsDefinitions().length + 1}`,
+        durationWeeks: 0,
+        subRoundBookerIds: undefined,
+        bookedWeeksLimit: 0,
+        allowDailyReservations: false,
+        bookers: this.bookers(),
+      },
+      ...ANIMATION_SETTINGS,
+    });
+    dialogRef.componentInstance.round.subscribe((round: ReservationRoundDefinition) => {
+      const newConfig = {...this.reservationRoundsConfig()};
+      newConfig.rounds.push(round);
+      this.reservationRoundsConfig.set(newConfig);
+      dialogRef.close();
+    });
+  }
+
   editRound(index: number) {
     const round = this.reservationRoundsDefinitions()[index];
 
     const dialogRef = this.dialog.open(EditRoundDialog, {
-      minWidth: '40vw',
       data: {
         name: round.name,
         durationWeeks: round.durationWeeks,
@@ -113,7 +132,6 @@ export class ReservationRoundsComponent implements OnDestroy {
       ...ANIMATION_SETTINGS,
     });
     dialogRef.componentInstance.round.subscribe((round: ReservationRoundDefinition) => {
-      console.log(`New round: ${JSON.stringify(round)}`);
       const newConfig = {...this.reservationRoundsConfig()};
       newConfig.rounds[index] = round;
       this.reservationRoundsConfig.set(newConfig);
@@ -121,7 +139,10 @@ export class ReservationRoundsComponent implements OnDestroy {
     });
 
     dialogRef.componentInstance.deleteRound.subscribe(() => {
-      console.log('Delete round');
+      const newConfig = {...this.reservationRoundsConfig()};
+      newConfig.rounds.splice(index, 1);
+      this.reservationRoundsConfig.set(newConfig);
+      dialogRef.close();
     });
   }
 

--- a/hosting/src/app/app.routes.ts
+++ b/hosting/src/app/app.routes.ts
@@ -3,6 +3,7 @@ import {ReservationsComponent} from './reservations.component';
 import {AdminComponent} from './admin/admin.component';
 import {FloorPlanComponent} from './admin/floor-plans.component';
 import {UnitPricingComponent} from './admin/unit-pricing.component';
+import {ReservationRoundsComponent} from './admin/reservation-rounds.component';
 
 export const routes: Routes = [
   {path: 'reservations', component: ReservationsComponent},
@@ -13,6 +14,10 @@ export const routes: Routes = [
       {
         path: 'floor-plans',
         component: FloorPlanComponent,
+      },
+      {
+        path: 'reservation-rounds',
+        component: ReservationRoundsComponent,
       },
       {
         path: 'unit-pricing',

--- a/hosting/src/app/reservations.component.css
+++ b/hosting/src/app/reservations.component.css
@@ -1,0 +1,4 @@
+mat-card {
+  margin-top: 1em;
+  margin-bottom: 1em;
+}

--- a/hosting/src/app/reservations.component.html
+++ b/hosting/src/app/reservations.component.html
@@ -41,7 +41,19 @@
       [reservations]="(reservations$ | async) || []"
       [unitPricing]="(unitPricing$ | async) || {}"
     />
-    <round-config [rounds$]="reservationRounds$" [bookers]="bookers"/>
+    <mat-card>
+      <mat-card-header>
+        <h1>Reservation Rounds</h1>
+      </mat-card-header>
+      <mat-card-content>
+        <round-config [rounds$]="reservationRounds$" [bookers]="bookers"/>
+        @if (isAdmin()) {
+          <button mat-button class="secondary-button" routerLink="/admin/reservation-rounds">
+            Manage rounds
+          </button>
+        }
+      </mat-card-content>
+    </mat-card>
     <audit-log [reservationsAuditLog$]="reservationsAuditLog$" [bookers]="bookers" [units]="units"/>
   } @else {
     <p>

--- a/hosting/src/app/reservations.component.ts
+++ b/hosting/src/app/reservations.component.ts
@@ -28,6 +28,9 @@ import {MatFormField, MatOption, MatSelect} from '@angular/material/select';
 import {FormsModule} from '@angular/forms';
 import {MatLabel} from '@angular/material/form-field';
 import {AuditLogComponent} from './reservations/audit-log.component';
+import {MatButton} from '@angular/material/button';
+import {RouterLink} from '@angular/router';
+import {MatCard, MatCardContent, MatCardHeader} from '@angular/material/card';
 
 
 @Component({
@@ -50,8 +53,14 @@ import {AuditLogComponent} from './reservations/audit-log.component';
     FormsModule,
     MatLabel,
     AuditLogComponent,
+    MatButton,
+    RouterLink,
+    MatCardContent,
+    MatCardHeader,
+    MatCard,
   ],
   templateUrl: './reservations.component.html',
+  styleUrl: './reservations.component.css',
 })
 export class ReservationsComponent implements OnDestroy {
   private readonly auth = inject(Auth);

--- a/hosting/src/app/reservations/reservation-rounds-service.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.ts
@@ -67,19 +67,18 @@ export class ReservationRoundsService implements OnDestroy {
     return roundsConfig.rounds.map(round => {
       const roundStart = previousEndDate;
       if (round.durationWeeks && round.subRoundBookerIds?.length) {
-        throw new Error(`Round #${round.position} "${round.name}" cannot have both durationWeeks and bookerOrder`);
+        throw new Error(`Round "${round.name}" cannot have both durationWeeks and bookerOrder`);
       }
 
       const durationWeeks = round.durationWeeks || round.subRoundBookerIds?.length;
       if (!durationWeeks || durationWeeks < 1) {
-        throw new Error(`Round #${round.position} "${round.name}" must have durationWeeks or bookerOrder`);
+        throw new Error(`Round "${round.name}" must have durationWeeks or bookerOrder`);
       }
 
       const roundEnd = roundStart.plus({days: durationWeeks * 7 - 1});
       previousEndDate = roundEnd.plus({days: 1});
       return {
         name: round.name,
-        position: round.position,
         startDate: roundStart,
         endDate: roundEnd,
         subRoundBookerIds: round.subRoundBookerIds || [],

--- a/hosting/src/app/reservations/reserve-dialog.component.ts
+++ b/hosting/src/app/reservations/reserve-dialog.component.ts
@@ -152,7 +152,7 @@ export class ReserveDialog {
     const _this = this;
 
     return (date: DateTime | null) => {
-      return !!date && !_this.blockedDates.has(date.toISO()!);
+      return !!date && !_this.blockedDates.has(date.toISODate()!);
     }
   }
 

--- a/hosting/src/app/reservations/round-config.component.html
+++ b/hosting/src/app/reservations/round-config.component.html
@@ -10,7 +10,7 @@
             {{ bookerFor(bookerId)?.name || 'unknown' }}
           </li>
         }
-        @if (round.bookedWeeksLimit > 0 ) {
+        @if (round.bookedWeeksLimit > 0) {
           <li>
             Booking limit: {{ round.bookedWeeksLimit }} weeks
           </li>

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -73,6 +73,7 @@ export interface ReservationRoundDefinition {
 }
 
 export interface ReservationRoundsConfig {
+  id: string;
   year: number;
   startDate: string;
   rounds: ReservationRoundDefinition[];

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -56,7 +56,6 @@ export interface ReservationAuditLog {
 }
 
 export interface ReservationRound {
-  position: number;
   name: string;
   startDate: DateTime;
   endDate: DateTime;
@@ -66,7 +65,6 @@ export interface ReservationRound {
 }
 
 export interface ReservationRoundDefinition {
-  position: number;
   name: string;
   durationWeeks?: number;
   subRoundBookerIds?: string[];

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -319,7 +319,7 @@ export class WeekTableComponent {
 
     return new Set(otherReservations.flatMap(otherReservation => {
       const days = otherReservation.endDate.diff(otherReservation.startDate, 'days').days;
-      return [...Array(days).keys()].map(offset => otherReservation.startDate.plus({days: offset}).toISO());
+      return [...Array(days).keys()].map(offset => otherReservation.startDate.plus({days: offset}).toISODate());
     }));
 
   }


### PR DESCRIPTION
Fixes #69 

The admin can now manage reservation rounds.

<img width="368" alt="Screenshot 2025-01-12 at 10 14 46 PM" src="https://github.com/user-attachments/assets/c16ed7af-cb8d-4de1-8ff3-a3f7bf67694b" />

This brings us to a new admin panel:

<img width="497" alt="Screenshot 2025-01-12 at 10 14 58 PM" src="https://github.com/user-attachments/assets/aba46d49-1589-4cc0-93e9-7fc5c18d00c9" />

Changes are previewed before being saved:

<img width="401" alt="Screenshot 2025-01-12 at 10 15 23 PM" src="https://github.com/user-attachments/assets/10be9abf-dbda-4935-8b45-e63e83b994e5" />

Rounds may be modified:

<img width="310" alt="Screenshot 2025-01-12 at 10 15 40 PM" src="https://github.com/user-attachments/assets/36492adf-f727-4ec0-b68c-14af45146b85" />

(or added)