### PR TITLE
Let the administrator set their own password

### DIFF
--- a/hosting/src/app/admin/passwords.component.html
+++ b/hosting/src/app/admin/passwords.component.html
@@ -3,6 +3,12 @@
     <h1>Passwords</h1>
   </mat-card-header>
   <mat-card-content>
+    <div>
+      Administrator
+      <button mat-icon-button (click)="editPassword(undefined)">
+        <mat-icon>edit</mat-icon>
+      </button>
+    </div>
     @for (booker of bookers(); track booker.id) {
       <div>
         {{ booker.name }}

--- a/hosting/src/app/admin/passwords.component.ts
+++ b/hosting/src/app/admin/passwords.component.ts
@@ -10,6 +10,7 @@ import {MatDialog} from "@angular/material/dialog";
 import {Booker} from '../types';
 import {PasswordDialog} from './password-dialog.component';
 import {Functions, httpsCallable} from '@angular/fire/functions';
+import {Auth, updatePassword} from '@angular/fire/auth';
 
 @Component({
   selector: 'passwords',
@@ -24,6 +25,7 @@ import {Functions, httpsCallable} from '@angular/fire/functions';
   templateUrl: './passwords.component.html',
 })
 export class PasswordsComponent {
+  private readonly auth = inject(Auth);
   private readonly dataService = inject(DataService);
   private readonly dialog = inject(MatDialog);
   private readonly functions = inject(Functions);
@@ -34,9 +36,18 @@ export class PasswordsComponent {
   constructor() {
   }
 
-  editPassword(booker: Booker) {
+  editPassword(booker?: Booker) {
+    const userId = booker?.userId || this.auth.currentUser?.uid;
+    if (!userId) {
+      this.dialog.open(ErrorDialog, {
+        data: "No user ID found",
+        ...ANIMATION_SETTINGS,
+      });
+      return;
+    }
+
     const dialogRef = this.dialog.open(PasswordDialog, {
-      data: booker.name,
+      data: booker?.name || "Admin",
       ...ANIMATION_SETTINGS,
     })
 
@@ -45,15 +56,30 @@ export class PasswordsComponent {
         return;
       }
 
-      const callable = httpsCallable(this.functions, 'setUserPassword');
-      callable({userId: booker.userId, password: result}).then(() => {
-        this.snackBar.open('Password updated successfully', 'Ok', {duration: 3000});
-      }).catch((error: any) => {
-        this.dialog.open(ErrorDialog, {
-          data: error.message,
-          ...ANIMATION_SETTINGS,
+      if (!booker) {
+        // Changing an admin's password happens through the client (logged in as admin)
+
+        updatePassword(this.auth.currentUser!!, result).then(() => {
+          this.snackBar.open('Password updated successfully', 'Ok', {duration: 3000});
+        }).catch((error) => {
+          this.dialog.open(ErrorDialog, {
+            data: error.message,
+            ...ANIMATION_SETTINGS,
+          });
         });
-      });
+      } else {
+        // Changing other users' passwords happens through our backend
+
+        const callable = httpsCallable(this.functions, 'setUserPassword');
+        callable({userId, password: result}).then(() => {
+          this.snackBar.open('Password updated successfully', 'Ok', {duration: 3000});
+        }).catch((error: Error) => {
+          this.dialog.open(ErrorDialog, {
+            data: error.message,
+            ...ANIMATION_SETTINGS,
+          });
+        });
+      }
     });
   }
 }


### PR DESCRIPTION
On the admin password panel, add an "administrator" line for the admin to change their own password.

<img width="272" alt="Screenshot 2025-01-18 at 9 51 36 PM" src="https://github.com/user-attachments/assets/122f48dc-d255-4da4-b633-81908051a67e" />

Changing other users' passwords goes through our backend (to use the admin SDK). But admin passwords can be changed by the client as usual, because we're changing the logged-in  user.

This does not support reauthenticating the user if they haven't logged in recently enough. We'll need to see what the error experience is like.

Fixes #85