### PR TITLE
Restrict admin routes to admins

### DIFF
--- a/hosting/src/app/app.routes.ts
+++ b/hosting/src/app/app.routes.ts
@@ -1,4 +1,4 @@
-import {Routes} from '@angular/router';
+import {ActivatedRouteSnapshot, CanActivateFn, RouterStateSnapshot, Routes} from '@angular/router';
 import {ReservationsComponent} from './reservations.component';
 import {AdminComponent} from './admin/admin.component';
 import {FloorPlanComponent} from './admin/floor-plans.component';
@@ -6,12 +6,23 @@ import {UnitPricingComponent} from './admin/unit-pricing.component';
 import {ReservationRoundsComponent} from './admin/reservation-rounds.component';
 import {PasswordsComponent} from './admin/passwords.component';
 import {AnnualDocumentsComponent} from './admin/annual-documents.component';
+import {DataService} from './data-service';
+import {inject} from '@angular/core';
+
+const isAdminGuard: CanActivateFn = (
+  _next: ActivatedRouteSnapshot,
+  _state: RouterStateSnapshot) => {
+  const dataService = inject(DataService);
+  return dataService.isAdmin();
+}
 
 export const routes: Routes = [
   {path: 'reservations', component: ReservationsComponent},
   {
     path: 'admin',
     component: AdminComponent,
+    canActivate: [isAdminGuard],
+    canActivateChild: [isAdminGuard],
     children: [
       {
         path: 'annual-documents',


### PR DESCRIPTION
Fixes #63 

Guard the admin routes with an admin check. Users get redirected to the base URL– it doesn't seem to actually load properly, they need to refresh. Well, that's what you get for trying to access the admin panel without authorization! ⛔ 