### PR TITLE
Restrict storage writes to admins

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -56,15 +56,14 @@ export const setUserPassword = onCall(
       throw new HttpsError("failed-precondition", "Must be admin");
     }
     // Get the list of admins
-    const query = await db.collection("permissions").get();
+    const query = await db.collection("adminUserIds").get();
 
     if (query.docs.length === 0) {
-      throw new HttpsError("internal", "Permissions document not found");
+      throw new HttpsError("internal", "Admin user IDs not found");
     }
-    const permissions = query.docs[0].data();
+    const adminUserIds = query.docs.map((it) => it.id);
 
-    const adminIds = permissions.adminUserIds as string[];
-    if (!adminIds.includes(request.auth.uid)) {
+    if (!adminUserIds.includes(request.auth.uid)) {
       throw new HttpsError("failed-precondition", "Must be admin");
     }
 

--- a/hosting/src/app/app.routes.ts
+++ b/hosting/src/app/app.routes.ts
@@ -13,7 +13,7 @@ const isAdminGuard: CanActivateFn = (
   _next: ActivatedRouteSnapshot,
   _state: RouterStateSnapshot) => {
   const dataService = inject(DataService);
-  return dataService.isAdmin();
+  return dataService.isAdmin$;
 }
 
 export const routes: Routes = [

--- a/hosting/src/app/reservations.component.html
+++ b/hosting/src/app/reservations.component.html
@@ -53,7 +53,6 @@
       [currentBooker]="currentBooker()"
       [weeks]="(weeks$ | async) || []"
       [units]="units()"
-      [permissions]="(permissions$ | async) || {adminUserIds: []}"
       [pricingTiers]="(pricingTiers$ | async) || {}"
       [reservations]="(reservations$ | async) || []"
       [unitPricing]="(unitPricing$ | async) || {}"

--- a/hosting/src/app/reservations.component.ts
+++ b/hosting/src/app/reservations.component.ts
@@ -95,7 +95,6 @@ export class ReservationsComponent implements OnDestroy {
   reservations$: Observable<Reservation[]>;
   reservationsAuditLog$: Observable<ReservationAuditLog[]>;
   units: Signal<BookableUnit[]>;
-  permissions$: Observable<Permissions>;
   pricingTiers$: Observable<{ [key: string]: PricingTier }>;
   unitPricing$: Observable<UnitPricingMap>;
 
@@ -108,7 +107,6 @@ export class ReservationsComponent implements OnDestroy {
     const dataService = this.dataService;
     this.annualDocumentFilename = dataService.annualDocumentFilename;
     this.bookers = dataService.bookers;
-    this.permissions$ = dataService.permissions$;
     this.pricingTiers$ = dataService.pricingTiers$;
     this.reservationRounds$ = reservationRoundsService.reservationRounds$;
     this.reservations$ = dataService.reservations$;

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -112,7 +112,6 @@ export class WeekTableComponent {
   private _bookers: WritableSignal<Booker[]> = signal([]);
   private _currentBooker: WritableSignal<Booker | undefined> = signal(undefined);
   private _reservations: Reservation[] = [];
-  private _permissions: Permissions = {adminUserIds: []};
   private _pricingTiers: PricingTierMap = {};
   private _units: BookableUnit[] = [];
   private _weeks: ReservableWeek[] = [];
@@ -203,12 +202,6 @@ export class WeekTableComponent {
   @Input()
   set weeks(value: ReservableWeek[]) {
     this._weeks = value;
-    this.buildTableRows();
-  }
-
-  @Input()
-  set permissions(value: Permissions) {
-    this._permissions = value;
     this.buildTableRows();
   }
 

--- a/storage.rules
+++ b/storage.rules
@@ -5,8 +5,12 @@ rules_version = '2';
 //    /databases/(default)/documents/users/$(request.auth.uid)).data.isAdmin;
 service firebase.storage {
   match /b/{bucket}/o {
+    function isAdmin() {
+      return firestore.exists(/databases/(default)/documents/adminUserIds/$(request.auth.uid));
+    }
     match /{allPaths=**} {
-      allow read, write: if request.auth != null;
+      allow read: if request.auth != null;
+      allow write: if isAdmin();
     }
   }
 }


### PR DESCRIPTION
Fixes #64

Any logged-in user can read stored documents, but only admins can create/edit/delete storage files.