### PR TITLE
Deploy storage rules

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -39,11 +39,6 @@ jobs:
         run: |
           npm install
           npm run build
-      - name: Build functions
-        working-directory: ./functions
-        run: |
-          npm install
-          npm run build
       - name: Install Firebase CLI
         run: |
           npm install -g firebase-tools

--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -59,7 +59,13 @@ jobs:
       - name: Deploy functions
         run: |
           echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}" | base64 --decode > "google-application-credentials.json"
-          firebase deploy --only functions --non-interactive --debug
+          firebase deploy --only functions --non-interactive
+        env:
+          GOOGLE_APPLICATION_CREDENTIALS: "google-application-credentials.json"
+      - name: Deploy storage
+        run: |
+          echo "${{ secrets.FIREBASE_SERVICE_ACCOUNT_BASE64 }}" | base64 --decode > "google-application-credentials.json"
+          firebase deploy --only storage --non-interactive
         env:
           GOOGLE_APPLICATION_CREDENTIALS: "google-application-credentials.json"
       - name: Cleanup credentials


### PR DESCRIPTION
Fixes #73  : deploy storage rules in the github deploy action.

Along the way:
Fixes #61 : don't build functions separate from deploy step (which re-builds them)