### PR TITLE
Restrict most firestore writes to admins

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -2,8 +2,15 @@ rules_version = '2';
 
 service cloud.firestore {
   match /databases/{database}/documents {
-    match /{document=**} {
+    function isAdmin() {
+      return firestore.exists(/databases/(default)/documents/adminUserIds/$(request.auth.uid));
+    }
+    match /reservations {
       allow read, write: if request.auth != null;
+    }
+    match /{document=**} {
+      allow write: if isAdmin();
+      allow read: if request.auth != null;
     }
   }
 }


### PR DESCRIPTION
Fixes #91 

Every logged-in user can still edit the reservations, but only admins can edit the rest (mostly app config).