### PR TITLE
Add wildcard to reservations match

### DIFF
--- a/firestore.rules
+++ b/firestore.rules
@@ -5,7 +5,7 @@ service cloud.firestore {
     function isAdmin() {
       return exists(/databases/(default)/documents/adminUserIds/$(request.auth.uid));
     }
-    match /reservations {
+    match /reservations/{docId} {
       allow read, write: if request.auth != null;
     }
     match /{document=**} {


### PR DESCRIPTION
Fixes #91 … again

The Firestore rule needs to apply to documents, not collections. Oops.
Add a wildcard to match all documents in the reservations collection.

This lets non-admin users write reservations again.