### PR TITLE
Ignore auth type, doesn't seem to matter

### DIFF
--- a/functions/src/index.ts
+++ b/functions/src/index.ts
@@ -12,19 +12,15 @@ initializeApp();
 const db = getFirestore();
 
 async function authToWho(authType: string, authId: string | undefined): Promise<string> {
-  switch(authType) {
-    case "system":
-      return "System";
-    case "app_user": {
-      if (!authId) {
-        return "Unknown";
-      }
+  if (!authId) {
+    return "Unknown";
+  }
 
-      const user = await auth().getUser(authId);
-      return user.email || authId || "Unknown";
-    }
-    default:
-      return authId || "Unknown";
+  try {
+    const user = await auth().getUser(authId);
+    return user.email || authId;
+  } catch (error) {
+    return authId;
   }
 }
 
@@ -47,6 +43,7 @@ export const modifyDocument =
       }
 
       const {authType, authId} = event;
+      logger.info(`Getting 'who' for auth ${authType}:${authId}`)
       const who = await authToWho(authType, authId);
 
       const startDate = ((previousData?.startDate || newData?.startDate || "1900") as string);
@@ -60,7 +57,7 @@ export const modifyDocument =
         year: Number((startDate.substring(0, 4))),
         timestamp: new Date(),
       });
-      logger.info(`Reservation audit log created for action by ${who} (${authType} ${authId})`);
+      logger.info(`Reservation audit log created for action by ${who}`);
     }
   );
 


### PR DESCRIPTION
The auth type was a red herring, for a user the type is `api_key` (not `app_user` as I anticipated).
So, just always try looking up the user– only fall back to the id if the user lookup fails.

Unfortunately the local auth emulator doesn't have useful values so we have to test live 🎉 

example emulator log
```
>  {"severity":"INFO","message":"Reservation audit log created for action by fake-auth-id@gmail.com (unknown fake-auth-id@gmail.com)"}
```

Fixes #79 (for real I think)