### PR TITLE
Add admin panel for editing weeks

### DIFF
--- a/hosting/src/app/admin/admin.component.html
+++ b/hosting/src/app/admin/admin.component.html
@@ -28,6 +28,9 @@
         <mat-button-toggle value="reservation-rounds" routerLink="reservation-rounds">
           Reservation rounds
         </mat-button-toggle>
+        <mat-button-toggle value="weeks" routerLink="weeks">
+          Weeks
+        </mat-button-toggle>
         <mat-button-toggle value="unit-pricing" routerLink="unit-pricing">
           Unit pricing
         </mat-button-toggle>

--- a/hosting/src/app/admin/edit-week-dialog.component.html
+++ b/hosting/src/app/admin/edit-week-dialog.component.html
@@ -1,0 +1,51 @@
+<h2 mat-dialog-title>
+  @if (data.mode === 'edit') {
+    Modify week
+  } @else {
+    Add week
+  }
+</h2>
+
+<mat-dialog-content>
+  <div>
+    <mat-form-field>
+      <mat-label>Start date (Saturday)</mat-label>
+      <input
+        matInput
+        [matDatepicker]="picker"
+        [disabled]="data.mode === 'edit'"
+        [matDatepickerFilter]="dateFilter"
+        [(ngModel)]="startDate"
+        [min]="yearStart"
+        [max]="yearEnd"
+      />
+      <mat-datepicker-toggle matSuffix [for]="picker"></mat-datepicker-toggle>
+      <mat-datepicker #picker startView="month"></mat-datepicker>
+    </mat-form-field>
+  </div>
+
+  <div>
+    <mat-form-field>
+      <mat-label>Pricing tier</mat-label>
+      <mat-select [(ngModel)]="pricingTierId">
+        @for (tier of (pricingTiers$ | async); track tier.id) {
+          <mat-option [value]="tier.id">{{ tier.name }}</mat-option>
+        }
+      </mat-select>
+    </mat-form-field>
+  </div>
+</mat-dialog-content>
+
+<mat-dialog-actions>
+  @if (data.mode === 'edit') {
+    <button mat-button class="error-button" (click)="onDelete()">Delete</button>
+  }
+  <button mat-button class="secondary-button" [mat-dialog-close]="null">Cancel</button>
+  <button mat-button class="primary-button" (click)="onSubmit()" [disabled]="!isValid()">
+    @if (data.mode === 'edit') {
+      Save
+    } @else {
+      Add
+    }
+  </button>
+</mat-dialog-actions>

--- a/hosting/src/app/admin/edit-week-dialog.component.ts
+++ b/hosting/src/app/admin/edit-week-dialog.component.ts
@@ -1,0 +1,144 @@
+import {ChangeDetectionStrategy, Component, HostListener, inject, model, ModelSignal, output} from '@angular/core';
+import {
+  MAT_DIALOG_DATA,
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle
+} from '@angular/material/dialog';
+import {FormsModule} from '@angular/forms';
+import {MatFormField, MatLabel, MatSuffix} from '@angular/material/form-field';
+import {MatInput, MatInputModule} from '@angular/material/input';
+import {MatSelect} from '@angular/material/select';
+import {MatOption} from '@angular/material/core';
+import {MatButton} from '@angular/material/button';
+import {
+  MatDatepicker,
+  MatDatepickerInput,
+  MatDatepickerModule,
+  MatDatepickerToggle
+} from '@angular/material/datepicker';
+import {MatLuxonDateModule} from '@angular/material-luxon-adapter';
+import {AsyncPipe} from '@angular/common';
+import {DataService} from '../data-service';
+import {DateTime} from 'luxon';
+
+export type EditWeekMode = 'add' | 'edit';
+
+export interface EditWeekDialogData {
+  startDateISO?: string;
+  pricingTierId: string;
+  year: number;
+  existingStartDates: Set<string>;
+  mode: EditWeekMode;
+  // When adding, caller can suggest a default start date (ISO)
+  suggestedStartDateISO?: string;
+}
+
+export interface EditWeekDialogResult {
+  startDateISO: string;
+  pricingTierId: string;
+}
+
+@Component({
+  selector: 'app-edit-week-dialog',
+  templateUrl: 'edit-week-dialog.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatDialogContent,
+    MatDialogActions,
+    MatDialogClose,
+    MatDialogTitle,
+    FormsModule,
+    MatFormField,
+    MatLabel,
+    MatInput,
+    MatInputModule,
+    MatSelect,
+    MatOption,
+    MatButton,
+    MatSuffix,
+    MatDatepicker,
+    MatDatepickerInput,
+    MatDatepickerModule,
+    MatDatepickerToggle,
+    MatLuxonDateModule,
+    AsyncPipe,
+  ],
+})
+export class EditWeekDialog {
+  data = inject<EditWeekDialogData>(MAT_DIALOG_DATA);
+  readonly dialogRef = inject(MatDialogRef<EditWeekDialog>);
+  private readonly dataService = inject(DataService);
+
+  readonly pricingTiers$ = this.dataService.pricingTiers$;
+
+  readonly startDate: ModelSignal<DateTime | null> = model<DateTime | null>(null);
+  readonly pricingTierId: ModelSignal<string> = model('');
+
+  readonly mode: EditWeekMode;
+  // Limit datepicker to active year bounds
+  readonly yearStart!: DateTime;
+  readonly yearEnd!: DateTime;
+
+  // outputs
+  result = output<EditWeekDialogResult>();
+  deleteWeek = output<void>();
+
+  constructor() {
+    const d = this.data;
+    this.mode = d.mode;
+    this.startDate.set(d.startDateISO ? DateTime.fromISO(d.startDateISO) : null);
+    this.pricingTierId.set(d.pricingTierId);
+
+    // Initialize min/max bounds for the datepicker to current year
+    this.yearStart = DateTime.fromISO(`${d.year}-01-01`);
+    this.yearEnd = DateTime.fromISO(`${d.year}-12-31`);
+
+    // If adding and no explicit start date provided, use suggested date if available
+    if (this.mode === 'add' && !this.startDate() && d.suggestedStartDateISO) {
+      this.startDate.set(DateTime.fromISO(d.suggestedStartDateISO));
+    }
+  }
+
+  @HostListener('window:keyup.Enter', ['$event'])
+  onKeyPress(_event: KeyboardEvent): void {
+    if (this.isValid()) {
+      this.onSubmit();
+    }
+  }
+
+  isValid(): boolean {
+    return (!!this.startDate() || this.mode === 'edit') && !!this.pricingTierId();
+  }
+
+  // Used by mat-datepicker to filter valid selectable dates
+  dateFilter = (date: DateTime | null): boolean => {
+    if (!date) return false;
+    // Saturdays only
+    if (date.weekday !== 6) return false; // 6 = Saturday in Luxon
+
+    const iso = date.toISODate()!;
+
+    // cannot select dates already used as a start
+    if (this.data.existingStartDates.has(iso) && iso !== this.data.startDateISO) return false;
+
+    return true;
+  }
+
+  onSubmit(): void {
+    const startISO = this.mode === 'edit' ? this.data.startDateISO! : this.startDate()!.toISODate()!;
+    this.result.emit({
+      startDateISO: startISO,
+      pricingTierId: this.pricingTierId(),
+    });
+  }
+
+  onDelete(): void {
+    if (confirm(`Really delete week starting ${this.data.startDateISO}? This cannot be undone`)) {
+      this.deleteWeek.emit();
+    }
+  }
+}

--- a/hosting/src/app/admin/weeks.component.html
+++ b/hosting/src/app/admin/weeks.component.html
@@ -1,0 +1,25 @@
+<mat-card>
+  <mat-card-header>
+    <h1>Weeks for {{ year() }}</h1>
+  </mat-card-header>
+  <mat-card-content>
+    <mat-list>
+      @for (week of weeksSig(); track week.startDate) {
+        <mat-list-item>
+          <div>
+            <div matListItemTitle>
+              {{ formatDate(week.startDate) }} — {{ pricingTierName(week.pricingTierId) }}
+            </div>
+            <div matListItemLine>
+              <button mat-button class="secondary-button" (click)="editWeek($index)">Edit</button>
+              <button mat-button class="error-button" (click)="deleteWeek($index)">Delete</button>
+            </div>
+          </div>
+        </mat-list-item>
+      }
+    </mat-list>
+  </mat-card-content>
+  <mat-card-actions>
+    <button mat-button class="primary-button" (click)="addWeek()" [disabled]="allWeeksDefined()">Add week</button>
+  </mat-card-actions>
+</mat-card>

--- a/hosting/src/app/admin/weeks.component.ts
+++ b/hosting/src/app/admin/weeks.component.ts
@@ -1,0 +1,176 @@
+import {Component, computed, inject, signal, Signal} from '@angular/core';
+import {MatCard, MatCardActions, MatCardContent, MatCardHeader} from '@angular/material/card';
+import {DataService} from '../data-service';
+import {MatList, MatListItem, MatListItemLine, MatListItemTitle} from '@angular/material/list';
+import {MatButton} from '@angular/material/button';
+import {MatDialog} from '@angular/material/dialog';
+import {MatSnackBar} from '@angular/material/snack-bar';
+import {ReservableWeek, WeeksConfig} from '../types';
+import {EditWeekDialog, EditWeekDialogData, EditWeekDialogResult} from './edit-week-dialog.component';
+import {ANIMATION_SETTINGS} from '../app.config';
+import {DateTime} from 'luxon';
+
+@Component({
+  selector: 'app-weeks-admin',
+  standalone: true,
+  imports: [
+    MatCard,
+    MatCardHeader,
+    MatCardContent,
+    MatCardActions,
+    MatList,
+    MatListItem,
+    MatListItemLine,
+    MatListItemTitle,
+    MatButton,
+  ],
+  templateUrl: './weeks.component.html',
+})
+export class WeeksComponent {
+  private readonly dataService = inject(DataService);
+  private readonly dialog = inject(MatDialog);
+  private readonly snackBar = inject(MatSnackBar);
+
+  year: Signal<number> = computed(() => this.dataService.activeYear());
+
+  weeksSig = signal<ReservableWeek[]>([]);
+  weeksConfigIdSig = signal<string>('');
+  pricingTiers$ = this.dataService.pricingTiers$;
+  pricingTierMapSig = signal<Record<string, string>>({});
+
+  // Year bounds
+  readonly yearStart = computed(() => DateTime.fromISO(`${this.year()}-01-01`));
+  readonly yearEnd = computed(() => DateTime.fromISO(`${this.year()}-12-31`));
+
+  // Compute the next available Saturday starting from the first defined reservable week
+  nextAvailableStartISO = computed(() => {
+    const weeks = this.weeksSig();
+    if (!weeks) return undefined;
+
+    const existingSet = new Set(weeks.map(w => w.startDate));
+
+    // Determine the baseline start: first defined reservable week, else first Saturday of the year
+    let baseline: DateTime;
+    if (weeks.length > 0) {
+      const minISO = weeks.reduce((min, w) => min < w.startDate ? min : w.startDate, weeks[0].startDate);
+      baseline = DateTime.fromISO(minISO);
+    } else {
+      const ys = this.yearStart();
+      const offset = (6 - ys.weekday + 7) % 7; // Saturday is 6 in Luxon
+      baseline = ys.plus({days: offset});
+    }
+
+    // Ensure baseline is within the year bounds
+    if (baseline < this.yearStart()) baseline = this.yearStart();
+    if (baseline > this.yearEnd()) return undefined;
+
+    // Start from the baseline (assume Saturdays for weeks list); if baseline isn't Saturday, align to next Saturday
+    if (baseline.weekday !== 6) {
+      const delta = (6 - baseline.weekday + 7) % 7;
+      baseline = baseline.plus({days: delta});
+    }
+
+    // Iterate each Saturday until year end
+    for (let d = baseline; d <= this.yearEnd(); d = d.plus({weeks: 1})) {
+      const iso = d.toISODate()!;
+      if (!existingSet.has(iso)) {
+        return iso;
+      }
+    }
+
+    return undefined;
+  });
+
+  // Disable Add button when there is no valid Saturday left
+  allWeeksDefined = computed(() => !this.nextAvailableStartISO());
+
+  constructor() {
+    this.dataService.weeksConfig$.subscribe(cfg => {
+      this.weeksConfigIdSig.set(cfg.id || '');
+    });
+    this.dataService.weeks$.subscribe(weeks => {
+      const sorted = [...weeks].sort((a, b) => a.startDate.localeCompare(b.startDate));
+      this.weeksSig.set(sorted);
+    });
+
+    this.pricingTiers$.subscribe(tiers => {
+      const map: Record<string, string> = {};
+      tiers.forEach(t => map[t.id] = t.name);
+      this.pricingTierMapSig.set(map);
+    });
+  }
+
+  addWeek() {
+    const existingStarts = new Set(this.weeksSig().map(w => w.startDate));
+    const dialogRef = this.dialog.open(EditWeekDialog, {
+      data: {
+        startDateISO: undefined,
+        pricingTierId: '',
+        year: this.year(),
+        existingStartDates: existingStarts,
+        mode: 'add',
+        suggestedStartDateISO: this.nextAvailableStartISO(),
+      } as EditWeekDialogData,
+      ...ANIMATION_SETTINGS,
+    });
+
+    dialogRef.componentInstance.result.subscribe((result: EditWeekDialogResult) => {
+      if (!result) return;
+      const weeks = [...this.weeksSig()];
+      weeks.push({startDate: result.startDateISO, pricingTierId: result.pricingTierId});
+      const config: WeeksConfig = {id: this.weeksConfigIdSig(), year: this.year(), weeks};
+      this.dataService.updateWeeksConfig(config).then(() => {
+        this.snackBar.open('Week added', 'Ok', {duration: 3000});
+        dialogRef.close();
+      });
+    });
+  }
+
+  editWeek(index: number) {
+    const week = this.weeksSig()[index];
+    const existingStarts = new Set(this.weeksSig().map(w => w.startDate));
+    const dialogRef = this.dialog.open(EditWeekDialog, {
+      data: {
+        startDateISO: week.startDate,
+        pricingTierId: week.pricingTierId,
+        year: this.year(),
+        existingStartDates: existingStarts,
+        mode: 'edit',
+      } as EditWeekDialogData,
+      ...ANIMATION_SETTINGS,
+    });
+
+    dialogRef.componentInstance.result.subscribe((result: EditWeekDialogResult) => {
+      if (!result) return;
+      const weeks = [...this.weeksSig()];
+      weeks[index] = {startDate: week.startDate, pricingTierId: result.pricingTierId};
+      const config: WeeksConfig = {id: this.weeksConfigIdSig(), year: this.year(), weeks};
+      this.dataService.updateWeeksConfig(config).then(() => {
+        this.snackBar.open('Week updated', 'Ok', {duration: 3000});
+        dialogRef.close();
+      });
+    });
+
+    dialogRef.componentInstance.deleteWeek.subscribe(() => {
+      this.deleteWeek(index);
+      dialogRef.close();
+    });
+  }
+
+  deleteWeek(index: number) {
+    const weeks = [...this.weeksSig()];
+    weeks.splice(index, 1);
+    const config: WeeksConfig = {id: this.weeksConfigIdSig(), year: this.year(), weeks};
+    this.dataService.updateWeeksConfig(config).then(() => {
+      this.snackBar.open('Week deleted', 'Ok', {duration: 3000});
+    });
+  }
+
+  formatDate(iso: string): string {
+    return DateTime.fromISO(iso).toFormat('ccc DDD');
+  }
+
+  pricingTierName(id: string): string {
+    return this.pricingTierMapSig()[id] || '<tier not set>';
+  }
+}

--- a/hosting/src/app/app.routes.ts
+++ b/hosting/src/app/app.routes.ts
@@ -7,6 +7,7 @@ import {ReservationRoundsComponent} from './admin/reservation-rounds.component';
 import {PasswordsComponent} from './admin/passwords.component';
 import {AnnualDocumentsComponent} from './admin/annual-documents.component';
 import {DataService} from './data-service';
+import {WeeksComponent} from './admin/weeks.component';
 import {inject} from '@angular/core';
 
 const isAdminGuard: CanActivateFn = (
@@ -39,6 +40,10 @@ export const routes: Routes = [
       {
         path: 'reservation-rounds',
         component: ReservationRoundsComponent,
+      },
+      {
+        path: 'weeks',
+        component: WeeksComponent,
       },
       {
         path: 'unit-pricing',

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -14,13 +14,10 @@ export interface Booker {
   userId: string;
 }
 
-export interface ConfigData {
+export interface WeeksConfig {
+  id: string;
   year: number;
   weeks: ReservableWeek[];
-}
-
-export interface Permissions {
-  adminUserIds: string[];
 }
 
 export interface PricingTier {
@@ -28,8 +25,6 @@ export interface PricingTier {
   name: string;
   color: number[];
 }
-
-export type PricingTierMap = Record<string, PricingTier>;
 
 export interface ReservableWeek {
   startDate: string;


### PR DESCRIPTION
This lets the admin add/edit/delete reservable weeks:

<img width="1147" height="691" alt="Screenshot 2025-11-30 at 11 27 41 PM" src="https://github.com/user-attachments/assets/285626df-73ff-4d43-b5b7-527df29c6058" />

Editing a week lets you change the tier:

<img width="331" height="325" alt="Screenshot 2025-11-30 at 11 28 06 PM" src="https://github.com/user-attachments/assets/bd8d0291-1613-4e86-838f-559132081758" />

Adding a week defaults to the next available week after the 1st week:

<img width="714" height="494" alt="Screenshot 2025-11-30 at 11 28 20 PM" src="https://github.com/user-attachments/assets/61813ade-772b-4aea-acc3-78b37362d9b7" />
