### PR TITLE
Add ability to create new year

### DIFF
--- a/hosting/src/app/admin/add-year-dialog.component.ts
+++ b/hosting/src/app/admin/add-year-dialog.component.ts
@@ -1,0 +1,67 @@
+import { ChangeDetectionStrategy, Component, HostListener, inject, model, output } from '@angular/core';
+import {MatButton} from '@angular/material/button';
+import {
+  MatDialogActions,
+  MatDialogClose,
+  MatDialogContent,
+  MatDialogRef,
+  MatDialogTitle,
+} from '@angular/material/dialog';
+import {FormsModule} from '@angular/forms';
+import {MatFormField, MatLabel} from '@angular/material/form-field';
+import {MatInput, MatInputModule} from '@angular/material/input';
+
+@Component({
+  selector: 'app-add-year-dialog',
+  template: `
+    <h2 mat-dialog-title>Add year</h2>
+    <mat-dialog-content>
+      <mat-form-field appearance="fill">
+        <mat-label>Year</mat-label>
+        <input matInput type="number" [(ngModel)]="yearValue" (ngModelChange)="yearValue.set($event)" />
+      </mat-form-field>
+    </mat-dialog-content>
+    <mat-dialog-actions align="end">
+      <button mat-button mat-dialog-close>Cancel</button>
+      <button mat-raised-button color="primary" (click)="onSubmit()" [disabled]="!isValid()">Add</button>
+    </mat-dialog-actions>
+  `,
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  standalone: true,
+  imports: [
+    MatDialogContent,
+    MatFormField,
+    MatDialogActions,
+    MatDialogClose,
+    MatButton,
+    MatLabel,
+    MatDialogTitle,
+    FormsModule,
+    MatInputModule,
+    MatInput,
+  ]
+})
+export class AddYearDialog {
+  readonly dialogRef = inject(MatDialogRef<AddYearDialog>);
+
+  // Inputs via dialog config data aren't necessary; caller will set initial value via component API
+  readonly yearValue = model<number>(new Date().getFullYear() + 1);
+  readonly save = output<number>();
+
+  @HostListener('window:keyup.Enter', ['$event'])
+  onKeyPress(_event: KeyboardEvent): void {
+    if (this.isValid()) {
+      this.onSubmit();
+    }
+  }
+
+  isValid(): boolean {
+    const y = this.yearValue();
+    return !!y && y > 1900 && y < 3000;
+  }
+
+  onSubmit(): void {
+    this.save.emit(this.yearValue());
+    this.dialogRef.close();
+  }
+}

--- a/hosting/src/app/data-service.ts
+++ b/hosting/src/app/data-service.ts
@@ -429,4 +429,17 @@ export class DataService {
       (this.floorPlanFilenames as WritableSignal<string[]>).set(items)
     });
   }
+
+  async addYear(year: number) {
+    // Prevent duplicates
+    const existing = this.availableYearsSig();
+    if (existing.includes(year)) {
+      return;
+    }
+
+    const yearsCollection = collection(this.firestore, 'years');
+    await addDoc(yearsCollection, {
+      year,
+    });
+  }
 }

--- a/hosting/src/app/utility/year-selector.component.ts
+++ b/hosting/src/app/utility/year-selector.component.ts
@@ -3,6 +3,9 @@ import {FormsModule} from '@angular/forms';
 import {MatFormField, MatLabel} from '@angular/material/form-field';
 import {MatOption, MatSelect} from '@angular/material/select';
 import {DataService} from '../data-service';
+import {MatDialog} from '@angular/material/dialog';
+import {ANIMATION_SETTINGS} from '../app.config';
+import {AddYearDialog} from '../admin/add-year-dialog.component';
 
 @Component({
   selector: 'app-year-selector',
@@ -17,11 +20,14 @@ import {DataService} from '../data-service';
   template: `
     <mat-form-field>
       <mat-label>{{ label }}</mat-label>
-      <mat-select [(ngModel)]="selectedYear">
+      <mat-select [(ngModel)]="selectedYear" (selectionChange)="onSelectionChange($event.value)" (openedChange)="onOpenedChange($event)">
         @for (year of years(); track year) {
           <mat-option [value]="year">
             {{ year }}
           </mat-option>
+        }
+        @if (isAdmin()) {
+          <mat-option [value]="ADD_OPTION_VALUE" class="add-year-option">➕ Add year</mat-option>
         }
       </mat-select>
     </mat-form-field>
@@ -31,12 +37,43 @@ export class YearSelectorComponent {
   @Input() label = 'Viewing year';
 
   private readonly dataService = inject(DataService);
+  private readonly dialog = inject(MatDialog);
 
   years = this.dataService.availableYearsSig;
   selectedYear = model<number>(this.dataService.activeYear());
+  isAdmin = this.dataService.isAdmin;
+  readonly ADD_OPTION_VALUE = '__ADD_YEAR__';
+
+  private lastSelectedYear = this.dataService.activeYear();
 
   constructor() {
     // Forward changes back to the global activeYear
     this.selectedYear.subscribe(year => this.dataService.activeYear.set(year));
+  }
+
+  onOpenedChange(opened: boolean) {
+    if (opened) {
+      this.lastSelectedYear = this.selectedYear();
+    }
+  }
+
+  onSelectionChange(value: string | number) {
+    if (value === this.ADD_OPTION_VALUE) {
+      const years = this.years();
+      const defaultYear = (years[years.length - 1] || new Date().getFullYear()) + 1;
+      const dialogRef = this.dialog.open(AddYearDialog, {
+        ...ANIMATION_SETTINGS,
+      });
+      dialogRef.componentInstance.yearValue.set(defaultYear);
+      dialogRef.componentInstance.save.subscribe(async (year: number) => {
+        await this.dataService.addYear(year);
+        // Select the newly added year
+        this.selectedYear.set(year);
+        dialogRef.close();
+      });
+
+      // Revert selection in the dropdown until/if a year is added
+      setTimeout(() => this.selectedYear.set(this.lastSelectedYear));
+    }
   }
 }


### PR DESCRIPTION
Lets the admin create a new year:

<img width="247" height="237" alt="Screenshot 2025-11-30 at 11 46 40 PM" src="https://github.com/user-attachments/assets/c7ce993b-9f28-4ac4-bb3d-567e8dd1629d" />


This can then be populated with more data: reservation rounds, weeks, etc

Fixes #115 