### PR TITLE
Add empty state for reservation weeks table

### DIFF
--- a/hosting/src/app/week-table.component.css
+++ b/hosting/src/app/week-table.component.css
@@ -26,3 +26,8 @@ th.unit-header {
   padding-bottom: 0.75em;
   vertical-align: top;
 }
+
+.mat-no-data-cell {
+  padding: 30px;
+  text-align: center;
+}

--- a/hosting/src/app/week-table.component.html
+++ b/hosting/src/app/week-table.component.html
@@ -123,5 +123,10 @@
   <tr mat-row class="weeks-content" *matRowDef="let row; columns: displayedColumns"
       [style]="rowStyle(row.pricingTier)">
   </tr>
+  <tr class="mat-row" *matNoDataRow>
+    <td class="mat-cell" class="weeks-content" [attr.colspan]="displayedColumns.length">
+      <h2>No weeks configured for reservation.</h2>
+    </td>
+  </tr>
   <tr mat-footer-row class="pricing-footer" *matFooterRowDef="displayedColumns"></tr>
 </table>

--- a/hosting/src/app/week-table.component.ts
+++ b/hosting/src/app/week-table.component.ts
@@ -12,6 +12,7 @@ import {
   MatHeaderCellDef,
   MatHeaderRow,
   MatHeaderRowDef,
+  MatNoDataRow,
   MatRow,
   MatRowDef,
   MatTable
@@ -84,6 +85,7 @@ interface WeekReservation {
     AsyncPipe,
     MatButton,
     MatAnchor,
+    MatNoDataRow,
   ],
   templateUrl: './week-table.component.html',
   styleUrl: './week-table.component.css'


### PR DESCRIPTION
When there are no reservable weeks configured, display an empty state.

<img width="1152" height="422" alt="Screenshot 2026-01-03 at 9 59 06 PM" src="https://github.com/user-attachments/assets/3ed4a2e3-6706-4443-baab-b1b1854ae290" />

Fixes #117 
