### PR TITLE
Reservation rounds in days not weeks

### DIFF
--- a/.github/workflows/firebase-hosting-merge.yml
+++ b/.github/workflows/firebase-hosting-merge.yml
@@ -40,6 +40,7 @@ jobs:
         run: |
           npm install
           npm run lint
+          npm run test -- --watch=false --browsers=ChromeHeadless
           npm run build
       - name: Install Firebase CLI
         run: |

--- a/.github/workflows/firebase-hosting-pull-request.yml
+++ b/.github/workflows/firebase-hosting-pull-request.yml
@@ -41,6 +41,7 @@ jobs:
         run: |
           npm install
           npm run lint
+          npm run test -- --watch=false --browsers=ChromeHeadless
           npm run build
       - name: Build functions
         working-directory: ./functions

--- a/hosting/src/app/admin/edit-round-dialog.component.html
+++ b/hosting/src/app/admin/edit-round-dialog.component.html
@@ -35,16 +35,23 @@
     </mat-button-toggle-group>
     <div>&nbsp;</div>
   </div>
-  <p>Round duration:</p>
+  <p>Round type:</p>
   <div>
     <mat-button-toggle-group
       [(ngModel)]="isRoundRobin"
-      aria-label="Is round robin"
+      aria-label="Round type"
     >
       <mat-button-toggle [value]="true">Priority rounds</mat-button-toggle>
       <mat-button-toggle [value]="false">Duration</mat-button-toggle>
     </mat-button-toggle-group>
     <div>&nbsp;</div>
+  </div>
+  <div>
+    <mat-form-field>
+      <mat-label>{{ isRoundRobin() ? 'Sub-round duration (days)' : 'Duration (days)' }}</mat-label>
+      <input matInput type="number" [(ngModel)]="durationDays" min="1"/>
+      <mat-error>Duration must be at least one</mat-error>
+    </mat-form-field>
   </div>
   @if (isRoundRobin()) {
     @let numBookers = subRoundBookerIds()?.length || 0;
@@ -63,14 +70,6 @@
           </mat-list-item>
         }
       </mat-list>
-    </div>
-  } @else {
-    <div>
-      <mat-form-field>
-        <mat-label>Duration (weeks)</mat-label>
-        <input matInput type="number" [(ngModel)]="durationWeeks" min="1"/>
-        <mat-error>Duration must be at least one</mat-error>
-      </mat-form-field>
     </div>
   }
   <div>

--- a/hosting/src/app/admin/edit-round-dialog.component.ts
+++ b/hosting/src/app/admin/edit-round-dialog.component.ts
@@ -22,7 +22,7 @@ export interface EditRoundDialogData {
   existingPosition?: number;
   bookers: Booker[];
   name: string;
-  durationWeeks?: number;
+  durationDays: number;
   subRoundBookerIds?: string[];
   bookedWeeksLimit?: number;
   allowDailyReservations: boolean;
@@ -62,7 +62,7 @@ export class EditRoundDialog {
   readonly bookers: Booker[];
   readonly existingPosition: number | undefined;
   readonly name = model('');
-  readonly durationWeeks: ModelSignal<number | undefined> = model(undefined as number | undefined);
+  readonly durationDays: ModelSignal<number> = model(-1);
   readonly subRoundBookerIds: ModelSignal<string[] | undefined> = model(undefined as string[] | undefined);
   readonly bookingLimitWeeks: ModelSignal<number | undefined> = model(undefined as number | undefined);
   readonly allowDailyReservations = model(false);
@@ -79,7 +79,7 @@ export class EditRoundDialog {
     this.bookers = data.bookers;
     this.existingPosition = data.existingPosition;
     this.name.set(data.name);
-    this.durationWeeks.set(data.durationWeeks);
+    this.durationDays.set(data.durationDays);
     this.subRoundBookerIds.set(data.subRoundBookerIds);
     this.bookingLimitWeeks.set(data.bookedWeeksLimit || 0);
     this.allowDailyReservations.set(data.allowDailyReservations);
@@ -90,10 +90,8 @@ export class EditRoundDialog {
     this.isRoundRobin.subscribe((isRoundRobin) => {
       if (isRoundRobin) {
         this.subRoundBookerIds.set(this.bookers.map(b => b.id));
-        this.durationWeeks.set(undefined);
       } else {
         this.subRoundBookerIds.set(undefined);
-        this.durationWeeks.set(0);
       }
     });
   }
@@ -107,10 +105,8 @@ export class EditRoundDialog {
 
   isValid(): boolean {
     return this.name().length > 0 &&
-      (!!this.subRoundBookerIds() || !!this.durationWeeks()) &&
-      !(!!this.subRoundBookerIds() && !!this.durationWeeks()) &&
       (!this.subRoundBookerIds() || this.subRoundBookerIds()!.length > 0) &&
-      (!this.durationWeeks() || this.durationWeeks()! > 0);
+      (this.durationDays() > 0);
   }
 
   onSubmit(): void {
@@ -125,8 +121,8 @@ export class EditRoundDialog {
     if (this.subRoundBookerIds()) {
       round.subRoundBookerIds = this.subRoundBookerIds();
     }
-    if (this.durationWeeks()) {
-      round.durationWeeks = this.durationWeeks();
+    if (this.durationDays()) {
+      round.durationDays = this.durationDays();
     }
 
     this.round.emit(round);

--- a/hosting/src/app/admin/reservation-rounds.component.ts
+++ b/hosting/src/app/admin/reservation-rounds.component.ts
@@ -105,7 +105,7 @@ export class ReservationRoundsComponent implements OnDestroy {
     const dialogRef = this.dialog.open(EditRoundDialog, {
       data: {
         name: `Round ${this.reservationRoundsDefinitions().length + 1}`,
-        durationWeeks: 0,
+        durationDays: 0,
         bookedWeeksLimit: 0,
         allowDailyReservations: false,
         allowDeletions: false,
@@ -127,7 +127,7 @@ export class ReservationRoundsComponent implements OnDestroy {
     const dialogRef = this.dialog.open(EditRoundDialog, {
       data: {
         name: round.name,
-        durationWeeks: round.durationWeeks,
+        durationDays: round.durationDays,
         subRoundBookerIds: round.subRoundBookerIds,
         bookedWeeksLimit: round.bookedWeeksLimit,
         allowDailyReservations: round.allowDailyReservations || false,

--- a/hosting/src/app/app.component.spec.ts
+++ b/hosting/src/app/app.component.spec.ts
@@ -1,5 +1,7 @@
 import {TestBed} from '@angular/core/testing';
 import {AppComponent} from './app.component';
+import {Title} from '@angular/platform-browser';
+import reservationsAppConfig from './reservations-app.config.json';
 
 describe('AppComponent', () => {
   beforeEach(async () => {
@@ -14,16 +16,17 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have the 'reservations-app' title`, () => {
+  it(`should have the title from config`, () => {
     const fixture = TestBed.createComponent(AppComponent);
-    const app = fixture.componentInstance;
-    expect(app.title).toEqual('reservations-app');
+    fixture.detectChanges();
+    const titleService = TestBed.inject(Title);
+    expect(titleService.getTitle()).toEqual(reservationsAppConfig.applicationTitle);
   });
 
-  it('should render title', () => {
+  it('should render nothing in the template (only router-outlet)', () => {
     const fixture = TestBed.createComponent(AppComponent);
     fixture.detectChanges();
     const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, reservations-app');
+    expect(compiled.querySelector('router-outlet')).toBeTruthy();
   });
 });

--- a/hosting/src/app/reservations/reservation-rounds-service.spec.ts
+++ b/hosting/src/app/reservations/reservation-rounds-service.spec.ts
@@ -1,0 +1,146 @@
+import {TestBed} from '@angular/core/testing';
+import {ReservationRoundsService} from './reservation-rounds-service';
+import {DataService} from '../data-service';
+import {TodayService} from '../utility/today-service';
+import {DateTime} from 'luxon';
+import {BehaviorSubject} from 'rxjs';
+import {Booker, ReservationRoundsConfig} from '../types';
+import {signal} from '@angular/core';
+
+describe('ReservationRoundsService', () => {
+  let service: ReservationRoundsService;
+  let dataServiceSpy: Partial<DataService>;
+  let todayService: TodayService;
+
+  const mockBookers: Booker[] = [
+    {id: 'booker1', name: 'Booker 1', userId: 'user1'},
+    {id: 'booker2', name: 'Booker 2', userId: 'user2'},
+  ];
+
+  const mockConfig: ReservationRoundsConfig = {
+    id: 'config1',
+    year: 2026,
+    startDate: '2026-01-01',
+    rounds: [
+      {
+        name: 'Round 1',
+        subRoundBookerIds: ['booker1', 'booker2'],
+        durationDays: 6,
+      },
+      {
+        name: 'Round 2',
+        durationDays: 14,
+        bookedWeeksLimit: 1,
+      }
+    ]
+  };
+
+  beforeEach(() => {
+    dataServiceSpy = {
+      reservationRoundsConfig$: new BehaviorSubject(mockConfig),
+      bookers: signal(mockBookers),
+    };
+
+    todayService = new TodayService();
+    todayService.today = DateTime.fromISO('2026-01-01');
+
+    TestBed.configureTestingModule({
+      providers: [
+        ReservationRoundsService,
+        {provide: DataService, useValue: dataServiceSpy},
+        {provide: TodayService, useValue: todayService},
+      ]
+    });
+    service = TestBed.inject(ReservationRoundsService);
+    // Explicitly call the logic by subscribing to the signals
+    // or just let the constructor finish its subscriptions which should happen in TestBed.inject
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('definitionsToRounds', () => {
+    it('should convert config to rounds correctly', () => {
+      const rounds = service.definitionsToRounds(mockConfig);
+      expect(rounds.length).toBe(2);
+
+      const r1 = rounds[0];
+      expect(r1.name).toBe('Round 1');
+      expect(r1.startDate.toISODate()).toBe('2026-01-01');
+      expect(r1.endDate.toISODate()).toBe('2026-01-12'); // 2 subrounds * 6 days = 12 days. End date is start + 11.
+      expect(r1.subRounds.length).toBe(2);
+      expect(r1.subRounds[0].bookerId).toBe('booker1');
+      expect(r1.subRounds[0].startDate.toISODate()).toBe('2026-01-01');
+      expect(r1.subRounds[0].endDate.toISODate()).toBe('2026-01-06');
+      expect(r1.subRounds[1].bookerId).toBe('booker2');
+      expect(r1.subRounds[1].startDate.toISODate()).toBe('2026-01-07');
+      expect(r1.subRounds[1].endDate.toISODate()).toBe('2026-01-12');
+
+      const r2 = rounds[1];
+      expect(r2.name).toBe('Round 2');
+      expect(r2.startDate.toISODate()).toBe('2026-01-13');
+      expect(r2.endDate.toISODate()).toBe('2026-01-26'); // 2 weeks = 14 days. End date is start + 13.
+      expect(r2.subRounds.length).toBe(0);
+      expect(r2.bookedWeeksLimit).toBe(1);
+    });
+
+    it('should handle explicit durationDays in subrounds', () => {
+      const configWithShortSubrounds: ReservationRoundsConfig = {
+        ...mockConfig,
+        rounds: [
+          {
+            name: 'Short Round',
+            subRoundBookerIds: ['booker1', 'booker2'],
+            durationDays: 3,
+          }
+        ]
+      };
+      const rounds = service.definitionsToRounds(configWithShortSubrounds);
+      const r = rounds[0];
+      expect(r.subRounds[0].startDate.toISODate()).toBe('2026-01-01');
+      expect(r.subRounds[0].endDate.toISODate()).toBe('2026-01-03');
+      expect(r.subRounds[1].startDate.toISODate()).toBe('2026-01-04');
+      expect(r.subRounds[1].endDate.toISODate()).toBe('2026-01-06');
+      expect(r.endDate.toISODate()).toBe('2026-01-06');
+    });
+  });
+
+  describe('currentRound and currentSubRoundBooker', () => {
+    it('should identify the current round and subround booker', (done) => {
+      // Use toObservable for the signals to wait for emission if necessary
+      // but signals should be immediate.
+      // Let's force a tick or check if service values are set.
+
+      // Actually, since they are signals based on observables in constructor,
+      // they might need a cycle to update.
+      setTimeout(() => {
+        // Jan 1st is in Round 1, subround 1 (booker1)
+        expect(service.currentRound()?.name).withContext('Jan 1st Round').toBe('Round 1');
+        expect(service.currentSubRoundBooker()?.id).withContext('Jan 1st Booker').toBe('booker1');
+
+        // Jan 7th is in Round 1, subround 2 (booker2)
+        todayService.today = DateTime.fromISO('2026-01-07');
+        setTimeout(() => {
+          expect(service.currentRound()?.name).withContext('Jan 7th Round').toBe('Round 1');
+          expect(service.currentSubRoundBooker()?.id).withContext('Jan 7th Booker').toBe('booker2');
+
+          // Jan 13th is in Round 2, no subrounds
+          todayService.today = DateTime.fromISO('2026-01-13');
+          setTimeout(() => {
+            expect(service.currentRound()?.name).withContext('Jan 13th Round').toBe('Round 2');
+            expect(service.currentSubRoundBooker()).withContext('Jan 13th Booker').toBeUndefined();
+
+            // Feb 1st is after all rounds
+            todayService.today = DateTime.fromISO('2026-02-01');
+            setTimeout(() => {
+              expect(service.currentRound()).withContext('Feb 1st Round').toBeUndefined();
+              expect(service.currentSubRoundBooker()).withContext('Feb 1st Booker').toBeUndefined();
+              done();
+            });
+          });
+        });
+      });
+    });
+  });
+});

--- a/hosting/src/app/reservations/round-config.component.html
+++ b/hosting/src/app/reservations/round-config.component.html
@@ -3,12 +3,13 @@
     @for (round of rounds(); track round.startDate) {
       <li>
         Round {{ round.name }}: {{ round.startDate | shortDate }} – {{ round.endDate | shortDate }}
+        ({{ round.endDate.diff(round.startDate, 'days').days + 1 }} days)
         <ul>
-          @for (bookerId of round.subRoundBookerIds; track bookerId; let i = $index) {
+          @for (subRound of round.subRounds; track subRound.startDate) {
             <li>
-              {{ offsetDate(round.startDate, i) | shortDate }}
-              – {{ offsetDate(round.startDate, i + 1).plus({days: -1}) | shortDate }}:
-              {{ bookerFor(bookerId)?.name || 'unknown' }}
+              {{ subRound.startDate | shortDate }}
+              – {{ subRound.endDate | shortDate }}:
+              {{ bookerFor(subRound.bookerId)?.name || 'unknown' }}
             </li>
           }
           @if (round.bookedWeeksLimit > 0) {

--- a/hosting/src/app/reservations/round-config.component.ts
+++ b/hosting/src/app/reservations/round-config.component.ts
@@ -46,8 +46,4 @@ export class RoundConfigComponent implements OnDestroy {
   bookerFor(bookerId: string): Booker | undefined {
     return this.dataService.bookers().find(booker => booker.id === bookerId);
   }
-
-  offsetDate(date: DateTime, weeks: number): DateTime {
-    return date.plus({days: weeks * 7});
-  }
 }

--- a/hosting/src/app/types.ts
+++ b/hosting/src/app/types.ts
@@ -50,11 +50,17 @@ export interface ReservationAuditLog {
   after: Record<string, string | number | Timestamp>;
 }
 
+export interface ReservationSubRound {
+  bookerId: string;
+  startDate: DateTime;
+  endDate: DateTime;
+}
+
 export interface ReservationRound {
   name: string;
   startDate: DateTime;
   endDate: DateTime;
-  subRoundBookerIds: string[];
+  subRounds: ReservationSubRound[];
   bookedWeeksLimit: number;
   allowDailyReservations: boolean;
   allowDeletions: boolean;
@@ -62,7 +68,7 @@ export interface ReservationRound {
 
 export interface ReservationRoundDefinition {
   name: string;
-  durationWeeks?: number;
+  durationDays: number;
   subRoundBookerIds?: string[];
   bookedWeeksLimit?: number;
   allowDailyReservations?: boolean;


### PR DESCRIPTION
Fixes #130 

One subtlety is we're reading from firestore & migrating the data in-place.
Once all rounds are loaded & saved w/ this new code, we can remove that migration. See also: #137